### PR TITLE
Update Payloads

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -23,6 +23,7 @@ type Asset struct {
 	Name            string    `json:"name"`
 	Balance         string    `json:"balance"`
 	BalanceAsOf     time.Time `json:"balance_as_of"`
+	ToBase          float64   `json:"to_base"` // the balance converted to the user's primary currency
 	Currency        string    `json:"currency"`
 	Status          string    `json:"status"`
 	InstitutionName string    `json:"institution_name"`

--- a/plaid.go
+++ b/plaid.go
@@ -27,6 +27,7 @@ type PlaidAccount struct {
 	Status            string    `json:"status"`
 	LastImport        time.Time `json:"last_import"`
 	Balance           string    `json:"balance"`
+	ToBase            float64   `json:"to_base"` // the balance converted to the user's primary currency
 	Currency          string    `json:"currency"`
 	BalanceLastUpdate time.Time `json:"balance_last_update"`
 	Limit             int64     `json:"limit"`


### PR DESCRIPTION
The Assets Object and Plaid Accounts Object now include a to_base property which shows the account balance converted to the user's primary currency.