### PR TITLE
fix: Refactor response reading

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,6 +99,7 @@ func (c *Client) Get(ctx context.Context, path string, options map[string]string
 	if err != nil {
 		return nil, fmt.Errorf("request (%+v) failed: %w", req, err)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		var buf bytes.Buffer
@@ -116,7 +117,12 @@ func (c *Client) Get(ctx context.Context, path string, options map[string]string
 		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
-	return resp.Body, nil
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, resp.Body); err != nil {
+		return nil, fmt.Errorf("could not read response: %w", err)
+	}
+
+	return &buf, nil
 }
 
 func (c *Client) Put(ctx context.Context, path string, body interface{}) (io.Reader, error) {
@@ -142,6 +148,7 @@ func (c *Client) Put(ctx context.Context, path string, body interface{}) (io.Rea
 	if err != nil {
 		return nil, fmt.Errorf("request (%+v) failed: %w", req, err)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		var buf bytes.Buffer
@@ -159,7 +166,12 @@ func (c *Client) Put(ctx context.Context, path string, body interface{}) (io.Rea
 		return nil, fmt.Errorf("%s", resp.Status)
 	}
 
-	return resp.Body, nil
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, resp.Body); err != nil {
+		return nil, fmt.Errorf("could not read response: %w", err)
+	}
+
+	return &buf, nil
 }
 
 // ParseCurrency turns two strings into a money struct.

--- a/tags.go
+++ b/tags.go
@@ -23,7 +23,7 @@ func (c *Client) GetTags(ctx context.Context) ([]*Tag, error) {
 	validate := validator.New()
 	body, err := c.Get(ctx, "/v1/tags", nil)
 	if err != nil {
-		return nil, fmt.Errorf("get transactions: %w", err)
+		return nil, fmt.Errorf("get tags: %w", err)
 	}
 
 	resp := &TagsResponse{}


### PR DESCRIPTION
Copy the response body to a buf, so we can close the response body. Fixes two lint issues.

Fixed an error msg that had transactions instead of tags. 