### PR TITLE
bug: external id on transactions can be any string

### DIFF
--- a/transactions.go
+++ b/transactions.go
@@ -30,7 +30,7 @@ type Transaction struct {
 	IsGroup        bool   `json:"is_group"`
 	GroupID        int64  `json:"group_id"`
 	ParentID       int64  `json:"parent_id"`
-	ExternalID     int64  `json:"external_id"`
+	ExternalID     string `json:"external_id"`
 }
 
 // ParsedAmount turns the currency from lunchmoney into a Go currency.


### PR DESCRIPTION
According to docs, the external ID can be 75 character string: https://lunchmoney.dev/#transaction-object

I tried using external ID with my project and I noticed that it was throwing when parsing transactions.