### PR TITLE
feat(transactions): support insert transactions api

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -56,3 +56,35 @@ func (c *Client) GetAssets(ctx context.Context) ([]*Asset, error) {
 
 	return resp.Assets, nil
 }
+
+// UpdateAsset updates a singl LM asset.
+type UpdateAsset struct {
+	TypeName             *string `json:"type_name,omitempty"`
+	SubtypeName          *string `json:"subtype_name,omitempty"`
+	Name                 *string `json:"name,omitempty"`
+	Balance              *string `json:"balance,omitempty"`
+	BalanceAsOf          *string `json:"balance_as_of,omitempty"`
+	Currency             *string `json:"currency,omitempty"`
+	InstitutionName      *string `json:"institution_name,omitempty"`
+	ClosedOn             *string `json:"closed_on,omitempty"`
+	ExcludedTransactions *bool   `json:"excluded_transactions,omitempty"`
+}
+
+func (c *Client) UpdateAsset(ctx context.Context, id int64, asset *UpdateAsset) (*Asset, error) {
+	validate := validator.New()
+	if err := validate.Struct(asset); err != nil {
+		return nil, err
+	}
+
+	body, err := c.Put(ctx, fmt.Sprintf("/v1/assets/%d", id), asset)
+	if err != nil {
+		return nil, fmt.Errorf("put asset %d: %w", id, err)
+	}
+
+	resp := &Asset{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return resp, nil
+}

--- a/assets.go
+++ b/assets.go
@@ -21,6 +21,7 @@ type Asset struct {
 	TypeName        string    `json:"type_name"`
 	SubtypeName     string    `json:"subtype_name"`
 	Name            string    `json:"name"`
+	DisplayName     string    `json:"display_name"`
 	Balance         string    `json:"balance"`
 	BalanceAsOf     time.Time `json:"balance_as_of"`
 	ToBase          float64   `json:"to_base"` // the balance converted to the user's primary currency
@@ -62,6 +63,7 @@ type UpdateAsset struct {
 	TypeName             *string `json:"type_name,omitempty"`
 	SubtypeName          *string `json:"subtype_name,omitempty"`
 	Name                 *string `json:"name,omitempty"`
+	DisplayName          *string `json:"display_name,omitempty"`
 	Balance              *string `json:"balance,omitempty"`
 	BalanceAsOf          *string `json:"balance_as_of,omitempty"`
 	Currency             *string `json:"currency,omitempty"`

--- a/client.go
+++ b/client.go
@@ -62,14 +62,8 @@ type ErrorResponse struct {
 }
 
 func (e *ErrorResponse) Error() string {
-	if e.ErrorString != "" {
-		switch v := e.ErrorString.(type) {
-		case string:
-			return v
-		case []string:
-			return fmt.Sprintf("%s", v)
-		default:
-		}
+	if e.ErrorString != nil {
+		return fmt.Sprintf("%v", e.ErrorString)
 	}
 
 	msg := ""

--- a/client.go
+++ b/client.go
@@ -57,9 +57,8 @@ func NewClient(apikey string) (*Client, error) {
 
 // ErrorResponse is json if we get an error from the LM API.
 type ErrorResponse struct {
-	ErrorString   any    `json:"error,omitempty"`
-	ErrorName     string `json:"name,omitempty"`
-	MessageString string `json:"message,omitempty"`
+	ErrorString any   `json:"error,omitempty"`
+	ErrorsArray []any `json:"errors,omitempty"`
 }
 
 func (e *ErrorResponse) Error() string {
@@ -73,15 +72,12 @@ func (e *ErrorResponse) Error() string {
 		}
 	}
 
-	if e.MessageString != "" {
-		return e.MessageString
+	msg := ""
+	if len(e.ErrorsArray) > 0 {
+		msg = fmt.Sprintf("%v", e.ErrorsArray)
 	}
 
-	if e.ErrorName != "" {
-		return e.ErrorName
-	}
-
-	return ""
+	return msg
 }
 
 // Get makes a request using the client to the path specified with the

--- a/transactions.go
+++ b/transactions.go
@@ -30,7 +30,7 @@ type Transaction struct {
 	IsGroup        bool   `json:"is_group"`
 	GroupID        int64  `json:"group_id"`
 	ParentID       int64  `json:"parent_id"`
-	ExternalID     int64  `json:"external_id"`
+	ExternalID     string `json:"external_id"`
 }
 
 // ParsedAmount turns the currency from lunchmoney into a Go currency.


### PR DESCRIPTION
### Problem

Currently there is no way to insert new transactions with the current setup as it requires a post

### Changes

- Added new Post method that does an HTTP post
- Generalize HTTP methods with bodies to handle errors
- I noticed that the lunch api actually returns 200 when the request actually failed with an error code so I changed the do method to try to deserialize into the error object if it can and if it does, and the error field is populated, the method throws.


### Testing

Ran against Lunch Money API