### PR TITLE
Add Display Name to Plaid accounts

### DIFF
--- a/plaid.go
+++ b/plaid.go
@@ -20,6 +20,7 @@ type PlaidAccount struct {
 	ID                int64     `json:"id"`
 	DateLinked        string    `json:"date_linked"`
 	Name              string    `json:"name"`
+	DisplayName       string    `json:"display_name"`
 	Type              string    `json:"type"`
 	Subtype           string    `json:"subtype"`
 	Mask              string    `json:"mask"`


### PR DESCRIPTION
Display name of the account, if not set it will return a concatenated string of institution and account name.

See docs: https://lunchmoney.dev/#plaid-accounts-object