### PR TITLE
chore: move lint config to .golangci.yml and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,4 +24,3 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-          args: -E bodyclose,misspell,gosec,goconst,errorlint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         go:
           - "1.25.x"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  enable:
+    - bodyclose
+    - errorlint
+    - goconst
+    - gosec
+    - misspell


### PR DESCRIPTION
Follow-ups from #22.

- **`.golangci.yml`** replaces the inline `-E` flag list in the workflow, so a local `golangci-lint run` and CI enforce the same set instead of findings only appearing after a push. Verified parity: `golangci-lint linters` reports the same 10 enabled linters (`bodyclose errcheck errorlint goconst gosec govet ineffassign misspell staticcheck unused`) with the flags and with the config.
- **`fail-fast: false`** on the test matrix. In #22 a genuine 1.24 failure cancelled the 1.25/1.26/1.27 jobs, which then reported as failures rather than cancellations.
- **`dependabot.yml`** for `gomod` and `github-actions`, weekly. No `docker` ecosystem — this is a library.