### PR TITLE
feat: wrap tag writes

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,6 +70,10 @@ type ErrorResponse struct {
 
 	// StatusCode is the HTTP status the body arrived with.
 	StatusCode int `json:"-"`
+
+	// RawBody is the undecoded error body, for the endpoints that answer a
+	// failure with a shape of their own rather than message and errors.
+	RawBody []byte `json:"-"`
 }
 
 // ErrorEntry is a single problem reported inside an ErrorResponse. The API is
@@ -186,7 +190,7 @@ func (c *Client) do(ctx context.Context, method, path string, options map[string
 	// v2 reports failures with a 4xx or 5xx status rather than an error
 	// embedded in a 200, and answers writes with 201 or 204.
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		errResp := &ErrorResponse{StatusCode: resp.StatusCode}
+		errResp := &ErrorResponse{StatusCode: resp.StatusCode, RawBody: buf.Bytes()}
 		if err := json.Unmarshal(buf.Bytes(), errResp); err != nil {
 			// Not the documented error body: a proxy or gateway may have
 			// answered instead, so pass along whatever it said.
@@ -197,11 +201,14 @@ func (c *Client) do(ctx context.Context, method, path string, options map[string
 			return nil, fmt.Errorf("%s", resp.Status)
 		}
 
+		// Wrap even when the body carried no message of its own, so that
+		// errors.As still reaches the status code and the raw body.
+		prefix := resp.Status
 		if errResp.Error() != "" {
-			return nil, fmt.Errorf("%s: %w", resp.Status, errResp)
+			prefix += ": "
 		}
 
-		return nil, fmt.Errorf("%s", resp.Status)
+		return nil, fmt.Errorf("%s%w", prefix, errResp)
 	}
 
 	return &buf, nil

--- a/tags.go
+++ b/tags.go
@@ -3,8 +3,12 @@ package lunchmoney
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
+
+	"github.com/go-playground/validator/v10"
 )
 
 // TagsResponse is the response from getting all tags.
@@ -53,4 +57,123 @@ func (c *Client) GetTag(ctx context.Context, id int64) (*Tag, error) {
 	}
 
 	return resp, nil
+}
+
+// CreateTag is a tag to create. Name is required and has to be unique.
+type CreateTag struct {
+	Name            string `json:"name" validate:"required,min=1,max=100"`
+	Description     string `json:"description,omitempty" validate:"max=200"`
+	TextColor       string `json:"text_color,omitempty"`
+	BackgroundColor string `json:"background_color,omitempty"`
+	Archived        bool   `json:"archived,omitempty"`
+}
+
+// CreateTag creates a new tag and returns it.
+func (c *Client) CreateTag(ctx context.Context, tag *CreateTag) (*Tag, error) {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.StructCtx(ctx, tag); err != nil {
+		return nil, err
+	}
+
+	body, err := c.Post(ctx, "/tags", tag)
+	if err != nil {
+		return nil, fmt.Errorf("create tag: %w", err)
+	}
+
+	resp := &Tag{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return resp, nil
+}
+
+// UpdateTag holds the updatable fields of a tag. Only non-nil fields are sent,
+// which also means there is no way to send an explicit null: leaving ArchivedAt
+// nil keeps the stored value rather than clearing it.
+type UpdateTag struct {
+	Name            *string    `json:"name,omitempty" validate:"omitnil,min=1,max=100"`
+	Description     *string    `json:"description,omitempty" validate:"omitnil,max=200"`
+	TextColor       *string    `json:"text_color,omitempty"`
+	BackgroundColor *string    `json:"background_color,omitempty"`
+	Archived        *bool      `json:"archived,omitempty"`
+	ArchivedAt      *time.Time `json:"archived_at,omitempty"`
+}
+
+// UpdateTag modifies the tag with the given ID and returns it.
+func (c *Client) UpdateTag(ctx context.Context, id int64, tag *UpdateTag) (*Tag, error) {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.StructCtx(ctx, tag); err != nil {
+		return nil, err
+	}
+
+	body, err := c.Put(ctx, fmt.Sprintf("/tags/%d", id), tag)
+	if err != nil {
+		return nil, fmt.Errorf("update tag %d: %w", id, err)
+	}
+
+	resp := &Tag{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return resp, nil
+}
+
+// TagDependents counts the records that still reference a tag.
+type TagDependents struct {
+	Rules        int64 `json:"rules"`
+	Transactions int64 `json:"transactions"`
+}
+
+// TagInUseError is the 422 DeleteTag gets back when rules or transactions still
+// reference the tag. Deleting it anyway takes another call with force set.
+type TagInUseError struct {
+	TagName    string        `json:"tag_name"`
+	Dependents TagDependents `json:"dependents"`
+
+	// Err is the API error the dependents arrived as.
+	Err error `json:"-"`
+}
+
+func (e *TagInUseError) Error() string {
+	return fmt.Sprintf("tag %q is used by %d rules and %d transactions", e.TagName, e.Dependents.Rules, e.Dependents.Transactions)
+}
+
+func (e *TagInUseError) Unwrap() error { return e.Err }
+
+// DeleteTag deletes the tag with the given ID. Without force the API refuses to
+// delete a tag that rules or transactions still reference, and the returned
+// error is a *TagInUseError naming what depends on it.
+func (c *Client) DeleteTag(ctx context.Context, id int64, force bool) error {
+	options := map[string]string{}
+	if force {
+		options["force"] = "true"
+	}
+
+	if _, err := c.Delete(ctx, fmt.Sprintf("/tags/%d", id), options); err != nil {
+		if inUse := tagInUse(err); inUse != nil {
+			return fmt.Errorf("delete tag %d: %w", id, inUse)
+		}
+
+		return fmt.Errorf("delete tag %d: %w", id, err)
+	}
+
+	return nil
+}
+
+// tagInUse decodes the dependents out of a 422, or returns nil if err is
+// anything else.
+func tagInUse(err error) *TagInUseError {
+	var apiErr *ErrorResponse
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnprocessableEntity {
+		return nil
+	}
+
+	inUse := &TagInUseError{Err: err}
+	if decodeErr := json.Unmarshal(apiErr.RawBody, inUse); decodeErr != nil || inUse.TagName == "" {
+		return nil
+	}
+
+	return inUse
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,240 @@
+package lunchmoney
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTag(t *testing.T) {
+	tests := []struct {
+		name       string
+		tag        *CreateTag
+		statusCode int
+		response   string
+		wantBody   map[string]any
+		wantErr    string
+	}{
+		{
+			name:       "name only",
+			tag:        &CreateTag{Name: "Date Night"},
+			statusCode: http.StatusCreated,
+			response:   `{"id": 94350, "name": "Date Night", "description": null, "archived": false, "archived_at": null}`,
+			wantBody:   map[string]any{"name": "Date Night"},
+		},
+		{
+			name:       "with description and colors",
+			tag:        &CreateTag{Name: "Date Night", Description: "dinners", TextColor: "333", BackgroundColor: "FFE7D4", Archived: true},
+			statusCode: http.StatusCreated,
+			response:   `{"id": 94351, "name": "Date Night", "description": "dinners", "archived": true}`,
+			wantBody: map[string]any{
+				"name":             "Date Night",
+				"description":      "dinners",
+				"text_color":       "333",
+				"background_color": "FFE7D4",
+				"archived":         true,
+			},
+		},
+		{
+			name:    "name is required",
+			tag:     &CreateTag{},
+			wantErr: "Name",
+		},
+		{
+			name:    "name is too long",
+			tag:     &CreateTag{Name: strings.Repeat("a", 101)},
+			wantErr: "Name",
+		},
+		{
+			name:       "duplicate name",
+			tag:        &CreateTag{Name: "Date Night"},
+			statusCode: http.StatusBadRequest,
+			response:   `{"message": "Invalid Request Body", "errors": [{"errMsg": "Tag with name 'Date Night' already exists"}]}`,
+			wantErr:    "already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/tags", r.URL.Path)
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			tag, err := testClient(t, server).CreateTag(context.Background(), tt.tag)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.tag.Name, tag.Name)
+			assert.Equal(t, tt.wantBody, gotBody)
+		})
+	}
+}
+
+func TestUpdateTag(t *testing.T) {
+	name := "Updated Tag Name"
+	archived := true
+
+	tests := []struct {
+		name       string
+		tag        *UpdateTag
+		statusCode int
+		response   string
+		wantBody   map[string]any
+		wantErr    string
+	}{
+		{
+			name:       "name only",
+			tag:        &UpdateTag{Name: &name},
+			statusCode: http.StatusOK,
+			response:   `{"id": 94319, "name": "Updated Tag Name", "description": null}`,
+			// The fields left nil stay out of the request body entirely.
+			wantBody: map[string]any{"name": "Updated Tag Name"},
+		},
+		{
+			name:       "archive",
+			tag:        &UpdateTag{Archived: &archived},
+			statusCode: http.StatusOK,
+			response:   `{"id": 94319, "name": "Date Night", "archived": true}`,
+			wantBody:   map[string]any{"archived": true},
+		},
+		{
+			name:    "name cannot be empty",
+			tag:     &UpdateTag{Name: new(string)},
+			wantErr: "Name",
+		},
+		{
+			name:       "not found",
+			tag:        &UpdateTag{Name: &name},
+			statusCode: http.StatusNotFound,
+			response:   `{"message": "Not Found", "errors": [{"errMsg": "There is no tag with the id: 543210."}]}`,
+			wantErr:    "no tag with the id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPut, r.Method)
+				assert.Equal(t, "/tags/94319", r.URL.Path)
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			tag, err := testClient(t, server).UpdateTag(context.Background(), 94319, tt.tag)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, int64(94319), tag.ID)
+			assert.Equal(t, tt.wantBody, gotBody)
+		})
+	}
+}
+
+func TestDeleteTag(t *testing.T) {
+	tests := []struct {
+		name       string
+		force      bool
+		statusCode int
+		response   string
+		wantForce  string
+		wantErr    string
+	}{
+		{
+			name:       "deleted",
+			statusCode: http.StatusNoContent,
+		},
+		{
+			name:       "forced",
+			force:      true,
+			statusCode: http.StatusNoContent,
+			wantForce:  "true",
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			response:   `{"message": "Not Found", "errors": [{"errMsg": "There is no tag with the id: 543210."}]}`,
+			wantErr:    "no tag with the id",
+		},
+		{
+			name:       "still in use",
+			statusCode: http.StatusUnprocessableEntity,
+			response:   `{"tag_name": "Tag to be Deleted", "dependents": {"rules": 1, "transactions": 10}}`,
+			wantErr:    "used by 1 rules and 10 transactions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, "/tags/94319", r.URL.Path)
+				assert.Equal(t, tt.wantForce, r.URL.Query().Get("force"))
+
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			err := testClient(t, server).DeleteTag(context.Background(), 94319, tt.force)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestDeleteTagInUseIsInspectable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, err := w.Write([]byte(`{"tag_name": "Tag to be Deleted", "dependents": {"rules": 1, "transactions": 10}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	err := testClient(t, server).DeleteTag(context.Background(), 94317, false)
+	require.Error(t, err)
+
+	var inUse *TagInUseError
+	require.True(t, errors.As(err, &inUse))
+	assert.Equal(t, "Tag to be Deleted", inUse.TagName)
+	assert.Equal(t, int64(1), inUse.Dependents.Rules)
+	assert.Equal(t, int64(10), inUse.Dependents.Transactions)
+
+	// The API error the dependents arrived as stays reachable underneath.
+	var apiErr *ErrorResponse
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusUnprocessableEntity, apiErr.StatusCode)
+}


### PR DESCRIPTION
Adds `CreateTag`, `UpdateTag` and `DeleteTag`.

`DeleteTag` takes `force`. Without it the API answers a tag that rules or transactions still reference with a 422, which comes back as a `*TagInUseError` carrying the dependent counts rather than a bare status string.

To get at that body, a failing call now wraps an `ErrorResponse` even when the body had no `message`, and keeps the undecoded body on it as `RawBody`. The category equivalent has its own schema and is a separate PR.

Closes #27