### PR TITLE
feat: wrap POST /plaid_accounts/fetch

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,6 +22,11 @@ const (
 
 	// userAgent identifies this library to the API.
 	userAgent = "github.com/icco/lunchmoney"
+
+	// queryStartDate and queryEndDate name the date range query parameters
+	// that several endpoints share.
+	queryStartDate = "start_date"
+	queryEndDate   = "end_date"
 )
 
 type addAuthHeaderTransport struct {

--- a/plaid.go
+++ b/plaid.go
@@ -101,8 +101,8 @@ func (r *PlaidFetchFilters) ToMap() (map[string]string, error) {
 	ret := map[string]string{}
 
 	strs := map[string]*string{
-		"start_date": r.StartDate,
-		"end_date":   r.EndDate,
+		queryStartDate: r.StartDate,
+		queryEndDate:   r.EndDate,
 	}
 	for k, v := range strs {
 		if v != nil {

--- a/plaid.go
+++ b/plaid.go
@@ -3,10 +3,15 @@ package lunchmoney
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/Rhymond/go-money"
+	"github.com/go-playground/validator/v10"
 )
 
 // PlaidAccountsResponse is a list plaid accounts response.
@@ -74,4 +79,82 @@ func (c *Client) GetPlaidAccount(ctx context.Context, id int64) (*PlaidAccount, 
 	}
 
 	return resp, nil
+}
+
+// PlaidFetchFilters narrows what TriggerPlaidFetch asks Plaid for. All fields
+// are optional; a nil filter fetches every eligible account.
+type PlaidFetchFilters struct {
+	// StartDate and EndDate bound the transactions to fetch. The API requires
+	// both or neither, so required_with comes before omitnil: omitnil
+	// short-circuits the rest of the tag when the field is nil, which is
+	// exactly the case the pairing rule has to catch.
+	StartDate *string `validate:"required_with=EndDate,omitnil,datetime=2006-01-02"`
+	EndDate   *string `validate:"required_with=StartDate,omitnil,datetime=2006-01-02"`
+
+	// ID limits the fetch to a single Plaid account.
+	ID *int64
+}
+
+// ToMap converts the filters to a string map to be sent as query parameters.
+// If a field is nil, it will not be included in the map.
+func (r *PlaidFetchFilters) ToMap() (map[string]string, error) {
+	ret := map[string]string{}
+
+	strs := map[string]*string{
+		"start_date": r.StartDate,
+		"end_date":   r.EndDate,
+	}
+	for k, v := range strs {
+		if v != nil {
+			ret[k] = *v
+		}
+	}
+
+	if r.ID != nil {
+		ret["id"] = strconv.FormatInt(*r.ID, 10)
+	}
+
+	return ret, nil
+}
+
+// IsTooEarly reports whether err is a 425 Too Early response, which the API
+// returns when a Plaid fetch was already triggered within the last minute.
+func IsTooEarly(err error) bool {
+	var resp *ErrorResponse
+
+	return errors.As(err, &resp) && resp.StatusCode == http.StatusTooEarly
+}
+
+// TriggerPlaidFetch queues a background fetch of the latest data from Plaid.
+// The API answers 425 Too Early if a fetch was triggered within the last
+// minute; check for that with IsTooEarly.
+func (c *Client) TriggerPlaidFetch(ctx context.Context, filters *PlaidFetchFilters) ([]*PlaidAccount, error) {
+	options := map[string]string{}
+	if filters != nil {
+		validate := validator.New(validator.WithRequiredStructEnabled())
+		if err := validate.StructCtx(ctx, filters); err != nil {
+			return nil, err
+		}
+
+		maps, err := filters.ToMap()
+		if err != nil {
+			return nil, fmt.Errorf("convert filters to map: %w", err)
+		}
+		options = maps
+	}
+
+	// The filters are query parameters on a POST, which Client.Post cannot
+	// express.
+	body, err := c.do(ctx, http.MethodPost, "/plaid_accounts/fetch", options, nil)
+	if err != nil {
+		return nil, fmt.Errorf("trigger plaid fetch: %w", err)
+	}
+
+	// The spec documents no body on the 202, so an empty one is not an error.
+	resp := &PlaidAccountsResponse{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return resp.PlaidAccounts, nil
 }

--- a/plaid_test.go
+++ b/plaid_test.go
@@ -1,0 +1,207 @@
+package lunchmoney
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlaidFetchFilters_ToMap(t *testing.T) {
+	startDate := "2023-01-01"
+	endDate := "2023-12-31"
+	id := int64(119807)
+
+	tests := []struct {
+		name     string
+		filters  PlaidFetchFilters
+		expected map[string]string
+	}{
+		{
+			name: "all fields set",
+			filters: PlaidFetchFilters{
+				StartDate: &startDate,
+				EndDate:   &endDate,
+				ID:        &id,
+			},
+			expected: map[string]string{
+				"start_date": "2023-01-01",
+				"end_date":   "2023-12-31",
+				"id":         "119807",
+			},
+		},
+		{
+			name:     "no fields set",
+			filters:  PlaidFetchFilters{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "id only",
+			filters:  PlaidFetchFilters{ID: &id},
+			expected: map[string]string{"id": "119807"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.filters.ToMap()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestTriggerPlaidFetch(t *testing.T) {
+	startDate := "2023-01-01"
+	endDate := "2023-12-31"
+	id := int64(119807)
+
+	// The 425 body is the example the spec documents for the response.
+	tooEarlyBody := `{"message": "Too Early", "errors": [{"errMsg": "Please wait at least 60 seconds between fetch requests."}]}`
+
+	tests := []struct {
+		name        string
+		filters     *PlaidFetchFilters
+		statusCode  int
+		response    string
+		wantQuery   url.Values
+		wantIDs     []int64
+		wantErr     bool
+		wantTooEarl bool
+	}{
+		{
+			name:       "accepted",
+			statusCode: http.StatusAccepted,
+			response:   `{"plaid_accounts": [{"id": 119807, "name": "Checking"}]}`,
+			wantQuery:  url.Values{},
+			wantIDs:    []int64{119807},
+		},
+		{
+			name:       "accepted with no body",
+			statusCode: http.StatusAccepted,
+			response:   ``,
+			wantQuery:  url.Values{},
+			wantIDs:    nil,
+		},
+		{
+			name: "filters become query parameters",
+			filters: &PlaidFetchFilters{
+				StartDate: &startDate,
+				EndDate:   &endDate,
+				ID:        &id,
+			},
+			statusCode: http.StatusAccepted,
+			response:   `{"plaid_accounts": []}`,
+			wantQuery: url.Values{
+				"start_date": {"2023-01-01"},
+				"end_date":   {"2023-12-31"},
+				"id":         {"119807"},
+			},
+			wantIDs: []int64{},
+		},
+		{
+			name:        "too early",
+			statusCode:  http.StatusTooEarly,
+			response:    tooEarlyBody,
+			wantQuery:   url.Values{},
+			wantErr:     true,
+			wantTooEarl: true,
+		},
+		{
+			name:       "other errors are not too early",
+			statusCode: http.StatusBadRequest,
+			response:   `{"message": "Invalid Request Parameters", "errors": [{"errMsg": "Both 'start_date' and 'end_date' must be specified."}]}`,
+			wantQuery:  url.Values{},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			gotQuery := url.Values{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.Query()
+
+				w.WriteHeader(tt.statusCode)
+				if tt.response != "" {
+					_, err := w.Write([]byte(tt.response))
+					require.NoError(t, err)
+				}
+			}))
+			defer server.Close()
+
+			accounts, err := testClient(t, server).TriggerPlaidFetch(context.Background(), tt.filters)
+
+			assert.Equal(t, http.MethodPost, gotMethod)
+			assert.Equal(t, "/plaid_accounts/fetch", gotPath)
+			assert.Equal(t, tt.wantQuery, gotQuery)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantTooEarl, IsTooEarly(err))
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.False(t, IsTooEarly(err))
+
+			ids := []int64{}
+			for _, a := range accounts {
+				ids = append(ids, a.ID)
+			}
+			if tt.wantIDs == nil {
+				assert.Empty(t, accounts)
+			} else {
+				assert.Equal(t, tt.wantIDs, ids)
+			}
+		})
+	}
+}
+
+func TestTriggerPlaidFetchValidatesDatePairing(t *testing.T) {
+	// The API requires start_date and end_date together, so a lone date has to
+	// fail before we ever send the request.
+	date := "2023-01-01"
+	badDate := "01/01/2023"
+
+	tests := []struct {
+		name    string
+		filters *PlaidFetchFilters
+		wantErr bool
+	}{
+		{name: "start date only", filters: &PlaidFetchFilters{StartDate: &date}, wantErr: true},
+		{name: "end date only", filters: &PlaidFetchFilters{EndDate: &date}, wantErr: true},
+		{name: "both dates", filters: &PlaidFetchFilters{StartDate: &date, EndDate: &date}},
+		{name: "neither date", filters: &PlaidFetchFilters{}},
+		{name: "bad date format", filters: &PlaidFetchFilters{StartDate: &badDate, EndDate: &date}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer server.Close()
+
+			_, err := testClient(t, server).TriggerPlaidFetch(context.Background(), tt.filters)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.False(t, called)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.True(t, called)
+		})
+	}
+}

--- a/summary.go
+++ b/summary.go
@@ -115,8 +115,8 @@ type BudgetFilters struct {
 // as GET parameters. Unset optional fields are omitted.
 func (r *BudgetFilters) ToMap() (map[string]string, error) {
 	ret := map[string]string{
-		"start_date": r.StartDate,
-		"end_date":   r.EndDate,
+		queryStartDate: r.StartDate,
+		queryEndDate:   r.EndDate,
 	}
 
 	bools := map[string]*bool{

--- a/transactions.go
+++ b/transactions.go
@@ -123,8 +123,8 @@ func (r *TransactionFilters) ToMap() (map[string]string, error) {
 	ret := map[string]string{}
 
 	strs := map[string]*string{
-		"start_date":    r.StartDate,
-		"end_date":      r.EndDate,
+		queryStartDate:  r.StartDate,
+		queryEndDate:    r.EndDate,
 		"created_since": r.CreatedSince,
 		"updated_since": r.UpdatedSince,
 		"status":        r.Status,


### PR DESCRIPTION
Adds `TriggerPlaidFetch(ctx, *PlaidFetchFilters)`, wrapping `POST /plaid_accounts/fetch`. Filters cover the spec's `start_date`/`end_date`/`id` query params; `start_date` and `end_date` are validated as a pair (`required_with` precedes `omitnil`, since `omitnil` would otherwise short-circuit exactly the nil case the pairing rule must catch).

`IsTooEarly(err)` makes the expected 425 branchable — `errors.As` to the wrapped `*ErrorResponse`, compared against `http.StatusTooEarly`. No string matching. Note that on main the client only wraps `*ErrorResponse` when the body carries a message; the documented 425 body does, so this works, and #37/#38 close the empty-body gap.

The filters are query params on a POST, which the exported `Post` cannot express, so this calls the in-package `c.do` directly rather than growing the client's surface for one caller. The only client.go change is a const block beside `BaseAPIURL` naming the shared `start_date`/`end_date` query params, which goconst demanded once a third pair appeared; summary.go and transactions.go now use those constants too. That hunk is deliberately disjoint from the `RawBody` region #37 and #38 both touch.

Spec quirks: the 202 response documents no body at all, though the endpoint returns `{"plaid_accounts": [...]}`, so an empty 202 decodes to no accounts instead of an `io.EOF` error. And `id` is declared `format: int32` while the spec's own example value overflows int32, so it is an `*int64` here like every other ID in the library.

Closes #32