### PR TITLE
feat: wrap transaction deletes

### DIFF
--- a/client.go
+++ b/client.go
@@ -128,9 +128,15 @@ func (c *Client) Post(ctx context.Context, path string, body any) (io.Reader, er
 	return c.do(ctx, http.MethodPost, path, nil, body)
 }
 
-// Delete performs a DELETE request against the given path. v2 answers with 204 and no body.
-func (c *Client) Delete(ctx context.Context, path string, options map[string]string) (io.Reader, error) {
-	return c.do(ctx, http.MethodDelete, path, options, nil)
+// Delete performs a DELETE request against the given path, with options as query
+// parameters and an optional JSON body. v2 answers with 204 and no body.
+func (c *Client) Delete(ctx context.Context, path string, options map[string]string, body ...any) (io.Reader, error) {
+	var payload any
+	if len(body) > 0 {
+		payload = body[0]
+	}
+
+	return c.do(ctx, http.MethodDelete, path, options, payload)
 }
 
 // do issues one request. The return values are named so that a failure to

--- a/transactions.go
+++ b/transactions.go
@@ -324,3 +324,37 @@ func (c *Client) UpdateTransaction(ctx context.Context, id int64, ut *UpdateTran
 
 	return resp, nil
 }
+
+// DeleteTransaction deletes the transaction with the specified ID.
+//
+// The API refuses to delete a split or grouped transaction; unsplit or ungroup
+// it first. Deletion is not reversible.
+func (c *Client) DeleteTransaction(ctx context.Context, id int64) error {
+	if _, err := c.Delete(ctx, fmt.Sprintf("/transactions/%d", id), nil); err != nil {
+		return fmt.Errorf("delete transaction %d: %w", id, err)
+	}
+
+	return nil
+}
+
+// DeleteTransactionsRequest deletes transactions in bulk.
+//
+// The whole request fails if any ID is repeated, does not exist, or belongs to
+// a split or grouped transaction.
+type DeleteTransactionsRequest struct {
+	IDs []int64 `json:"ids" validate:"min=1,max=500"`
+}
+
+// DeleteTransactions deletes the transactions with the specified IDs.
+func (c *Client) DeleteTransactions(ctx context.Context, dtReq DeleteTransactionsRequest) error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.StructCtx(ctx, dtReq); err != nil {
+		return err
+	}
+
+	if _, err := c.Delete(ctx, "/transactions", nil, dtReq); err != nil {
+		return fmt.Errorf("delete transactions: %w", err)
+	}
+
+	return nil
+}

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -222,3 +222,102 @@ func TestUpdateTransaction(t *testing.T) {
 	assert.Equal(t, int64(42), got.ID)
 	assert.Equal(t, "Rent", got.Payee)
 }
+
+func TestDeleteTransactions(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantBody string
+		del      func(*Client) error
+	}{
+		{
+			name: "single",
+			path: "/transactions/42",
+			del: func(c *Client) error {
+				return c.DeleteTransaction(context.Background(), 42)
+			},
+		},
+		{
+			name:     "bulk",
+			path:     "/transactions",
+			wantBody: `{"ids": [1, 2, 3]}`,
+			del: func(c *Client) error {
+				return c.DeleteTransactions(context.Background(), DeleteTransactionsRequest{IDs: []int64{1, 2, 3}})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBody := ""
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, tt.path, r.URL.Path)
+				// Neither delete endpoint takes query parameters.
+				assert.Empty(t, r.URL.RawQuery)
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				gotBody = string(body)
+
+				// 204 with no body at all, which is what the API sends.
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			require.NoError(t, tt.del(testClient(t, server)))
+
+			if tt.wantBody == "" {
+				assert.Empty(t, gotBody)
+				return
+			}
+			assert.JSONEq(t, tt.wantBody, gotBody)
+		})
+	}
+}
+
+func TestDeleteTransactionsIDBounds(t *testing.T) {
+	ids := func(n int) []int64 {
+		out := make([]int64, n)
+		for i := range out {
+			out[i] = int64(i + 1)
+		}
+
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		ids     []int64
+		wantErr bool
+	}{
+		{name: "nil", ids: nil, wantErr: true},
+		{name: "empty", ids: []int64{}, wantErr: true},
+		{name: "one", ids: ids(1)},
+		{name: "five hundred", ids: ids(500)},
+		{name: "five hundred and one", ids: ids(501), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			err := testClient(t, server).DeleteTransactions(context.Background(), DeleteTransactionsRequest{IDs: tt.ids})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "IDs")
+				assert.False(t, called, "out of bounds ids should be rejected before the request")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.True(t, called)
+		})
+	}
+}


### PR DESCRIPTION
Adds `DeleteTransaction(ctx, id)` for `DELETE /transactions/{id}` and `DeleteTransactions(ctx, DeleteTransactionsRequest{IDs: ...})` for the bulk `DELETE /transactions`. Both return only an error: the API answers 204 with no body, so nothing is decoded. `IDs` is validated at 1-500 before the request goes out. Neither endpoint takes query params.

Touches client.go only at `Client.Delete` (lines 131-134 on main), which gains an optional variadic JSON body so the bulk form can send `{"ids": [...]}`. No new imports, and existing callers compile unchanged. That is disjoint from the `ErrorResponse.RawBody` hunk in #37 and #38, which I did not add - the bulk delete's 400/404 entries carry `ids_index`/`transaction_id`, and `ErrorEntry.UnmarshalJSON` already keeps those in `Extra`.

Tests live in transactions_test.go to stay clear of the other client.go PRs.

Closes #29
