### PR TITLE
feat: wrap budget upsert and delete

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,6 +70,10 @@ type ErrorResponse struct {
 
 	// StatusCode is the HTTP status the body arrived with.
 	StatusCode int `json:"-"`
+
+	// RawBody is the undecoded error body, for the endpoints that answer a
+	// failure with a shape of their own rather than message and errors.
+	RawBody []byte `json:"-"`
 }
 
 // ErrorEntry is a single problem reported inside an ErrorResponse. The API is
@@ -186,7 +190,7 @@ func (c *Client) do(ctx context.Context, method, path string, options map[string
 	// v2 reports failures with a 4xx or 5xx status rather than an error
 	// embedded in a 200, and answers writes with 201 or 204.
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		errResp := &ErrorResponse{StatusCode: resp.StatusCode}
+		errResp := &ErrorResponse{StatusCode: resp.StatusCode, RawBody: buf.Bytes()}
 		if err := json.Unmarshal(buf.Bytes(), errResp); err != nil {
 			// Not the documented error body: a proxy or gateway may have
 			// answered instead, so pass along whatever it said.
@@ -197,11 +201,14 @@ func (c *Client) do(ctx context.Context, method, path string, options map[string
 			return nil, fmt.Errorf("%s", resp.Status)
 		}
 
+		// Wrap even when the body carried no message of its own, so that
+		// errors.As still reaches the status code and the raw body.
+		prefix := resp.Status
 		if errResp.Error() != "" {
-			return nil, fmt.Errorf("%s: %w", resp.Status, errResp)
+			prefix += ": "
 		}
 
-		return nil, fmt.Errorf("%s", resp.Status)
+		return nil, fmt.Errorf("%s%w", prefix, errResp)
 	}
 
 	return &buf, nil

--- a/summary.go
+++ b/summary.go
@@ -3,7 +3,9 @@ package lunchmoney
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/Rhymond/go-money"
@@ -191,4 +193,114 @@ func (c *Client) GetBudgetSettings(ctx context.Context) (*BudgetSettings, error)
 	}
 
 	return resp, nil
+}
+
+// Budget is a single category's budget for one period.
+type Budget struct {
+	CategoryID int64   `json:"category_id"`
+	StartDate  string  `json:"start_date"`
+	Amount     string  `json:"amount"`
+	Currency   string  `json:"currency"`
+	ToBase     float64 `json:"to_base"`
+	Notes      string  `json:"notes"`
+}
+
+// ParsedAmount converts the budgeted amount and currency into a money.Money.
+func (b *Budget) ParsedAmount() (*money.Money, error) {
+	return ParseCurrency(b.Amount, b.Currency)
+}
+
+// UpsertBudget is a budget to set. StartDate has to be a period start for the
+// account, which GetBudgetSettings describes.
+type UpsertBudget struct {
+	StartDate  string `json:"start_date" validate:"required,datetime=2006-01-02"`
+	CategoryID int64  `json:"category_id" validate:"required"`
+	Amount     string `json:"amount" validate:"required"`
+
+	// Currency defaults to the account's primary currency when empty.
+	Currency string `json:"currency,omitempty"`
+
+	// Notes is a pointer so that an empty string clears the stored notes
+	// rather than being indistinguishable from leaving them alone.
+	Notes *string `json:"notes,omitempty" validate:"omitnil,max=350"`
+}
+
+// UpsertBudget sets the budget for a category and period, creating it if there
+// is none, and returns it.
+func (c *Client) UpsertBudget(ctx context.Context, budget *UpsertBudget) (*Budget, error) {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.StructCtx(ctx, budget); err != nil {
+		return nil, err
+	}
+
+	body, err := c.Put(ctx, "/budgets", budget)
+	if err != nil {
+		return nil, fmt.Errorf("upsert budget: %w", budgetInvalidPeriod(err))
+	}
+
+	resp := &Budget{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return resp, nil
+}
+
+// DeleteBudget removes the budget for a category and period. Removing a budget
+// that is not set succeeds.
+func (c *Client) DeleteBudget(ctx context.Context, categoryID int64, startDate string) error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.VarCtx(ctx, startDate, "required,datetime=2006-01-02"); err != nil {
+		return err
+	}
+
+	options := map[string]string{
+		"category_id": strconv.FormatInt(categoryID, 10),
+		"start_date":  startDate,
+	}
+
+	if _, err := c.Delete(ctx, "/budgets", options); err != nil {
+		return fmt.Errorf("delete budget: %w", budgetInvalidPeriod(err))
+	}
+
+	return nil
+}
+
+// BudgetInvalidPeriodError is the 400 the API answers with when a start date is
+// not a period start for the account. The budget calls return one so the valid
+// dates on either side of the rejected one can be reached with errors.As.
+type BudgetInvalidPeriodError struct {
+	Message            string `json:"message"`
+	ErrMsg             string `json:"errMsg"`
+	RequestedStartDate string `json:"requested_start_date"`
+
+	// PreviousValidStartDate and NextValidStartDate are empty when the
+	// requested date has no valid period start before or after it.
+	PreviousValidStartDate string `json:"previous_valid_start_date"`
+	NextValidStartDate     string `json:"next_valid_start_date"`
+
+	// Err is the API error the period details arrived as.
+	Err error `json:"-"`
+}
+
+func (e *BudgetInvalidPeriodError) Error() string {
+	return fmt.Sprintf("%s (requested %q, previous valid %q, next valid %q)", e.ErrMsg, e.RequestedStartDate, e.PreviousValidStartDate, e.NextValidStartDate)
+}
+
+func (e *BudgetInvalidPeriodError) Unwrap() error { return e.Err }
+
+// budgetInvalidPeriod replaces a 400 that carries period details with them, and
+// passes any other error, a plain validation 400 included, through untouched.
+func budgetInvalidPeriod(err error) error {
+	var apiErr *ErrorResponse
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusBadRequest {
+		return err
+	}
+
+	period := &BudgetInvalidPeriodError{Err: err}
+	if jsonErr := json.Unmarshal(apiErr.RawBody, period); jsonErr != nil || period.RequestedStartDate == "" {
+		return err
+	}
+
+	return period
 }

--- a/summary.go
+++ b/summary.go
@@ -302,9 +302,30 @@ func budgetInvalidPeriod(err error) error {
 	}
 
 	period := &BudgetInvalidPeriodError{Err: err}
-	if jsonErr := json.Unmarshal(apiErr.RawBody, period); jsonErr != nil || period.RequestedStartDate == "" {
-		return err
+	if jsonErr := json.Unmarshal(apiErr.RawBody, period); jsonErr == nil && period.RequestedStartDate != "" {
+		return period
 	}
 
-	return period
+	// The API documents this 400 as either the flat shape above or an ordinary
+	// error body with the period details on the entry, so check there too.
+	for _, entry := range apiErr.Errors {
+		requested, _ := entry.Extra["requested_start_date"].(string)
+		if requested == "" {
+			continue
+		}
+
+		previous, _ := entry.Extra["previous_valid_start_date"].(string)
+		next, _ := entry.Extra["next_valid_start_date"].(string)
+
+		return &BudgetInvalidPeriodError{
+			Message:                apiErr.Message,
+			ErrMsg:                 entry.Message,
+			RequestedStartDate:     requested,
+			PreviousValidStartDate: previous,
+			NextValidStartDate:     next,
+			Err:                    err,
+		}
+	}
+
+	return err
 }

--- a/summary.go
+++ b/summary.go
@@ -12,6 +12,10 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+// startDateParam is the query parameter the budget endpoints take a period
+// start in.
+const startDateParam = "start_date"
+
 // BudgetSummary is the budget and activity rollup for a date range. It replaces
 // the per-category, per-month Budget list v1 returned from /budgets.
 type BudgetSummary struct {
@@ -117,8 +121,8 @@ type BudgetFilters struct {
 // as GET parameters. Unset optional fields are omitted.
 func (r *BudgetFilters) ToMap() (map[string]string, error) {
 	ret := map[string]string{
-		"start_date": r.StartDate,
-		"end_date":   r.EndDate,
+		startDateParam: r.StartDate,
+		"end_date":     r.EndDate,
 	}
 
 	bools := map[string]*bool{
@@ -255,8 +259,8 @@ func (c *Client) DeleteBudget(ctx context.Context, categoryID int64, startDate s
 	}
 
 	options := map[string]string{
-		"category_id": strconv.FormatInt(categoryID, 10),
-		"start_date":  startDate,
+		"category_id":  strconv.FormatInt(categoryID, 10),
+		startDateParam: startDate,
 	}
 
 	if _, err := c.Delete(ctx, "/budgets", options); err != nil {

--- a/summary_test.go
+++ b/summary_test.go
@@ -1,0 +1,234 @@
+package lunchmoney
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// invalidPeriodBody is the error the API answers with when a start date is not
+// a period start for the account.
+const invalidPeriodBody = `{
+	"message": "Invalid Request",
+	"errMsg": "The requested start date is not a valid budget period start for this account.",
+	"requested_start_date": "2025-01-15",
+	"previous_valid_start_date": "2025-01-01",
+	"next_valid_start_date": "2025-02-01"
+}`
+
+func TestUpsertBudget(t *testing.T) {
+	notes := "Monthly groceries"
+	cleared := ""
+	tooLong := strings.Repeat("x", 351)
+
+	tests := []struct {
+		name        string
+		budget      *UpsertBudget
+		wantBody    map[string]any
+		statusCode  int
+		response    string
+		errContains string
+		wantPeriod  bool
+		want        *Budget
+	}{
+		{
+			name:   "new budget",
+			budget: &UpsertBudget{StartDate: "2025-01-01", CategoryID: 315177, Amount: "500", Currency: "usd", Notes: &notes},
+			wantBody: map[string]any{
+				"start_date":  "2025-01-01",
+				"category_id": float64(315177),
+				"amount":      "500",
+				"currency":    "usd",
+				"notes":       "Monthly groceries",
+			},
+			response: `{"category_id": 315177, "start_date": "2025-01-01", "amount": "500.0000", "currency": "usd", "to_base": 500.0, "notes": "Monthly groceries"}`,
+			want:     &Budget{CategoryID: 315177, StartDate: "2025-01-01", Amount: "500.0000", Currency: "usd", ToBase: 500, Notes: "Monthly groceries"},
+		},
+		{
+			name:     "empty notes clear the stored ones",
+			budget:   &UpsertBudget{StartDate: "2025-02-01", CategoryID: 315177, Amount: "42.5000", Notes: &cleared},
+			wantBody: map[string]any{"start_date": "2025-02-01", "category_id": float64(315177), "amount": "42.5000", "notes": ""},
+			response: `{"category_id": 315177, "start_date": "2025-02-01", "amount": "42.5000", "currency": "usd", "to_base": 42.5, "notes": ""}`,
+			want:     &Budget{CategoryID: 315177, StartDate: "2025-02-01", Amount: "42.5000", Currency: "usd", ToBase: 42.5},
+		},
+		{
+			name:        "missing start date is rejected before the request",
+			budget:      &UpsertBudget{CategoryID: 315177, Amount: "500"},
+			errContains: "StartDate",
+		},
+		{
+			name:        "missing category is rejected before the request",
+			budget:      &UpsertBudget{StartDate: "2025-01-01", Amount: "500"},
+			errContains: "CategoryID",
+		},
+		{
+			name:        "missing amount is rejected before the request",
+			budget:      &UpsertBudget{StartDate: "2025-01-01", CategoryID: 315177},
+			errContains: "Amount",
+		},
+		{
+			name:        "a start date that is not a date is rejected before the request",
+			budget:      &UpsertBudget{StartDate: "January 2025", CategoryID: 315177, Amount: "500"},
+			errContains: "StartDate",
+		},
+		{
+			name:        "too long a note is rejected before the request",
+			budget:      &UpsertBudget{StartDate: "2025-01-01", CategoryID: 315177, Amount: "500", Notes: &tooLong},
+			errContains: "Notes",
+		},
+		{
+			name:        "start date is not a period start",
+			budget:      &UpsertBudget{StartDate: "2025-01-15", CategoryID: 315177, Amount: "500"},
+			wantBody:    map[string]any{"start_date": "2025-01-15", "category_id": float64(315177), "amount": "500"},
+			statusCode:  http.StatusBadRequest,
+			response:    invalidPeriodBody,
+			errContains: "not a valid budget period start",
+			wantPeriod:  true,
+		},
+		{
+			name:        "unknown category",
+			budget:      &UpsertBudget{StartDate: "2025-01-01", CategoryID: 1, Amount: "500"},
+			wantBody:    map[string]any{"start_date": "2025-01-01", "category_id": float64(1), "amount": "500"},
+			statusCode:  http.StatusBadRequest,
+			response:    `{"message": "Invalid Request Body", "errors": [{"errMsg": "Category ID does not exist"}]}`,
+			errContains: "Category ID does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/budgets", r.URL.Path)
+				assert.Equal(t, http.MethodPut, r.Method)
+
+				got := map[string]any{}
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+				assert.Equal(t, tt.wantBody, got)
+
+				if tt.statusCode != 0 {
+					w.WriteHeader(tt.statusCode)
+				}
+
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			got, err := testClient(t, server).UpsertBudget(context.Background(), tt.budget)
+			if tt.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assertInvalidPeriod(t, err, tt.wantPeriod)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDeleteBudget(t *testing.T) {
+	tests := []struct {
+		name        string
+		categoryID  int64
+		startDate   string
+		statusCode  int
+		response    string
+		errContains string
+		wantPeriod  bool
+	}{
+		{
+			name:       "deleted",
+			categoryID: 315177,
+			startDate:  "2025-01-01",
+			statusCode: http.StatusNoContent,
+		},
+		{
+			name:        "a start date that is not a date is rejected before the request",
+			categoryID:  315177,
+			startDate:   "01/01/2025",
+			errContains: "datetime",
+		},
+		{
+			name:        "a missing start date is rejected before the request",
+			categoryID:  315177,
+			errContains: "required",
+		},
+		{
+			name:        "start date is not a period start",
+			categoryID:  315177,
+			startDate:   "2025-01-15",
+			statusCode:  http.StatusBadRequest,
+			response:    invalidPeriodBody,
+			errContains: "not a valid budget period start",
+			wantPeriod:  true,
+		},
+		{
+			name:        "unknown category",
+			categoryID:  1,
+			startDate:   "2025-01-01",
+			statusCode:  http.StatusBadRequest,
+			response:    `{"message": "Invalid Request Body", "errors": [{"errMsg": "Category ID does not exist"}]}`,
+			errContains: "Category ID does not exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/budgets", r.URL.Path)
+				assert.Equal(t, http.MethodDelete, r.Method)
+
+				// The budget to delete is identified by query parameters,
+				// which url.Values sorts by name.
+				assert.Equal(t, "category_id="+strconv.FormatInt(tt.categoryID, 10)+"&start_date="+tt.startDate, r.URL.RawQuery)
+
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			err := testClient(t, server).DeleteBudget(context.Background(), tt.categoryID, tt.startDate)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContains)
+			assertInvalidPeriod(t, err, tt.wantPeriod)
+		})
+	}
+}
+
+// assertInvalidPeriod checks whether err carries the period details, and that
+// anything that does still unwraps to the API error.
+func assertInvalidPeriod(t *testing.T, err error, want bool) {
+	t.Helper()
+
+	var periodErr *BudgetInvalidPeriodError
+	if !want {
+		assert.False(t, errors.As(err, &periodErr))
+		return
+	}
+
+	require.True(t, errors.As(err, &periodErr))
+	assert.Equal(t, "2025-01-15", periodErr.RequestedStartDate)
+	assert.Equal(t, "2025-01-01", periodErr.PreviousValidStartDate)
+	assert.Equal(t, "2025-02-01", periodErr.NextValidStartDate)
+
+	var apiErr *ErrorResponse
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+}

--- a/summary_test.go
+++ b/summary_test.go
@@ -24,6 +24,19 @@ const invalidPeriodBody = `{
 	"next_valid_start_date": "2025-02-01"
 }`
 
+// invalidPeriodNestedBody is the same error in the other shape the API
+// documents for it, with the period details on the error entry rather than at
+// the top level. Both the upsert and delete examples in the spec use this one.
+const invalidPeriodNestedBody = `{
+	"message": "Invalid Request",
+	"errors": [{
+		"errMsg": "The requested start date is not a valid budget period start for this account.",
+		"requested_start_date": "2025-01-15",
+		"previous_valid_start_date": "2025-01-01",
+		"next_valid_start_date": "2025-02-01"
+	}]
+}`
+
 func TestUpsertBudget(t *testing.T) {
 	notes := "Monthly groceries"
 	cleared := ""
@@ -90,6 +103,15 @@ func TestUpsertBudget(t *testing.T) {
 			wantBody:    map[string]any{"start_date": "2025-01-15", "category_id": float64(315177), "amount": "500"},
 			statusCode:  http.StatusBadRequest,
 			response:    invalidPeriodBody,
+			errContains: "not a valid budget period start",
+			wantPeriod:  true,
+		},
+		{
+			name:        "start date is not a period start, details on the entry",
+			budget:      &UpsertBudget{StartDate: "2025-01-15", CategoryID: 315177, Amount: "500"},
+			wantBody:    map[string]any{"start_date": "2025-01-15", "category_id": float64(315177), "amount": "500"},
+			statusCode:  http.StatusBadRequest,
+			response:    invalidPeriodNestedBody,
 			errContains: "not a valid budget period start",
 			wantPeriod:  true,
 		},
@@ -170,6 +192,15 @@ func TestDeleteBudget(t *testing.T) {
 			startDate:   "2025-01-15",
 			statusCode:  http.StatusBadRequest,
 			response:    invalidPeriodBody,
+			errContains: "not a valid budget period start",
+			wantPeriod:  true,
+		},
+		{
+			name:        "start date is not a period start, details on the entry",
+			categoryID:  315177,
+			startDate:   "2025-01-15",
+			statusCode:  http.StatusBadRequest,
+			response:    invalidPeriodNestedBody,
 			errContains: "not a valid budget period start",
 			wantPeriod:  true,
 		},


### PR DESCRIPTION
Wraps `PUT /budgets` (`UpsertBudget`) and `DELETE /budgets` (`DeleteBudget`), alongside the existing budget reads in summary.go. Delete identifies its target by `category_id` and `start_date` query params, not a body.

A start date that is not a period start for the account comes back as a `BudgetInvalidPeriodError` with the requested date and the valid dates on either side, reachable with `errors.As` and distinguishable from a generic 400.

That error has a shape of its own rather than the usual `message`/`errors` pair, so it needs the `ErrorResponse.RawBody` hunk in client.go — the same hunk #37 and #38 add, reproduced byte for byte so those three conflict trivially.

Closes #33
