### PR TITLE
feat: wrap transaction attachments

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -1,0 +1,149 @@
+package lunchmoney
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// attachmentsPath is the collection the file_id endpoints hang off. It is not
+// nested under the transaction the file belongs to.
+const attachmentsPath = "/transactions/attachments"
+
+// quoteEscaper escapes a filename for a Content-Disposition header the same way
+// mime/multipart does for the parts it builds itself.
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+// AttachFileRequest is a file to upload and attach to a transaction.
+//
+// The API rejects files over 10MB, and accepts only image/jpeg, image/png,
+// application/pdf, image/heic and image/heif.
+type AttachFileRequest struct {
+	// Name is the filename the API stores and shows.
+	Name string `validate:"required"`
+
+	// File is read to the end and buffered in memory before the upload starts.
+	File io.Reader `validate:"required"`
+
+	// ContentType overrides the type derived from Name's extension, which is
+	// worth setting for the formats Go has no mapping for.
+	ContentType string
+
+	// Notes is optional free text stored alongside the file.
+	Notes string
+}
+
+// contentType is the caller's type, or the one Name's extension implies.
+func (a *AttachFileRequest) contentType() string {
+	if a.ContentType != "" {
+		return a.ContentType
+	}
+
+	if t := mime.TypeByExtension(filepath.Ext(a.Name)); t != "" {
+		return t
+	}
+
+	return "application/octet-stream"
+}
+
+// encode buffers the request as a multipart body and returns it with the
+// content type naming its boundary.
+func (a *AttachFileRequest) encode() (*bytes.Buffer, string, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	header := textproto.MIMEHeader{}
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, quoteEscaper.Replace(a.Name)))
+	header.Set("Content-Type", a.contentType())
+
+	part, err := w.CreatePart(header)
+	if err != nil {
+		return nil, "", fmt.Errorf("create file part: %w", err)
+	}
+
+	if _, err := io.Copy(part, a.File); err != nil {
+		return nil, "", fmt.Errorf("read file: %w", err)
+	}
+
+	if a.Notes != "" {
+		if err := w.WriteField("notes", a.Notes); err != nil {
+			return nil, "", fmt.Errorf("write notes: %w", err)
+		}
+	}
+
+	// Closing writes the trailing boundary, so the body is only complete once
+	// this succeeds.
+	if err := w.Close(); err != nil {
+		return nil, "", fmt.Errorf("finish multipart body: %w", err)
+	}
+
+	return &buf, w.FormDataContentType(), nil
+}
+
+// TransactionAttachmentURL is a signed link to download an attachment, and the
+// moment that link stops working.
+type TransactionAttachmentURL struct {
+	URL       string    `json:"url"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// AttachFileToTransaction uploads a file and attaches it to a transaction.
+func (c *Client) AttachFileToTransaction(ctx context.Context, id int64, af *AttachFileRequest) (*TransactionAttachment, error) {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.StructCtx(ctx, af); err != nil {
+		return nil, err
+	}
+
+	buf, contentType, err := af.encode()
+	if err != nil {
+		return nil, fmt.Errorf("attach file to transaction %d: %w", id, err)
+	}
+
+	// Multipart cannot go through Post, which always marshals JSON.
+	body, err := c.doBody(ctx, http.MethodPost, fmt.Sprintf("/transactions/%d/attachments", id), nil, buf, contentType)
+	if err != nil {
+		return nil, fmt.Errorf("attach file to transaction %d: %w", id, err)
+	}
+
+	resp := &TransactionAttachment{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetTransactionAttachmentURL returns a signed, expiring link to an attachment.
+func (c *Client) GetTransactionAttachmentURL(ctx context.Context, fileID int64) (*TransactionAttachmentURL, error) {
+	body, err := c.Get(ctx, fmt.Sprintf("%s/%d", attachmentsPath, fileID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("get transaction attachment %d: %w", fileID, err)
+	}
+
+	resp := &TransactionAttachmentURL{}
+	if err := json.NewDecoder(body).Decode(resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return resp, nil
+}
+
+// DeleteTransactionAttachment detaches a file from its transaction and deletes it.
+func (c *Client) DeleteTransactionAttachment(ctx context.Context, fileID int64) error {
+	if _, err := c.Delete(ctx, fmt.Sprintf("%s/%d", attachmentsPath, fileID), nil); err != nil {
+		return fmt.Errorf("delete transaction attachment %d: %w", fileID, err)
+	}
+
+	return nil
+}

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -101,10 +101,9 @@ func TestAttachFileToTransaction(t *testing.T) {
 				assert.Equal(t, "/transactions/42/attachments", r.URL.Path)
 				assert.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data;"))
 
-				require.NoError(t, r.ParseMultipartForm(1<<20))
-
-				// The spec names the file field "file"; the server has to see a
-				// well formed part under that name, not just the right header.
+				// The spec names the file field "file". FormFile parses the
+				// multipart body, so the server has to see a well formed part
+				// under that name, not just the right header.
 				file, header, err := r.FormFile("file")
 				require.NoError(t, err)
 				defer func() { require.NoError(t, file.Close()) }()

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -1,0 +1,308 @@
+package lunchmoney
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachFileToTransaction(t *testing.T) {
+	// The 201 example from the spec. It carries a source field the
+	// transactionAttachmentObject schema does not declare, which decoding
+	// ignores.
+	created := `{
+		"id": 1234567890,
+		"uploaded_by": 1,
+		"name": "receipt.png",
+		"type": "image/png",
+		"size": 4330,
+		"notes": null,
+		"source": "api",
+		"created_at": "2025-06-11T22:33:20.294Z"
+	}`
+
+	tests := []struct {
+		name        string
+		req         *AttachFileRequest
+		statusCode  int
+		response    string
+		wantName    string
+		wantType    string
+		wantContent string
+		wantErr     string
+	}{
+		{
+			name: "png with notes",
+			req: &AttachFileRequest{
+				Name:        "receipt.png",
+				File:        strings.NewReader("not really a png"),
+				ContentType: "image/png",
+				Notes:       "Test file attachment",
+			},
+			statusCode:  http.StatusCreated,
+			response:    created,
+			wantName:    "receipt.png",
+			wantType:    "image/png",
+			wantContent: "not really a png",
+		},
+		{
+			name: "pdf without notes",
+			req: &AttachFileRequest{
+				Name:        "statement.pdf",
+				File:        strings.NewReader("%PDF-1.4"),
+				ContentType: "application/pdf",
+			},
+			statusCode:  http.StatusCreated,
+			response:    created,
+			wantName:    "statement.pdf",
+			wantType:    "application/pdf",
+			wantContent: "%PDF-1.4",
+		},
+		{
+			name: "filename with a quote in it",
+			req: &AttachFileRequest{
+				Name:        `we"ird.png`,
+				File:        strings.NewReader("not really a png"),
+				ContentType: "image/png",
+			},
+			statusCode:  http.StatusCreated,
+			response:    created,
+			wantName:    `we"ird.png`,
+			wantType:    "image/png",
+			wantContent: "not really a png",
+		},
+		{
+			name: "file type the api refuses",
+			req: &AttachFileRequest{
+				Name:        "archive.zip",
+				File:        strings.NewReader("PK"),
+				ContentType: "application/zip",
+			},
+			statusCode:  http.StatusBadRequest,
+			response:    `{"message": "Invalid Request Body", "errors": [{"errMsg": "File type application/zip not allowed. Allowed types are: image/jpeg, image/png, application/pdf, image/heic, image/heif"}]}`,
+			wantName:    "archive.zip",
+			wantType:    "application/zip",
+			wantContent: "PK",
+			wantErr:     "Invalid Request Body: File type application/zip not allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/transactions/42/attachments", r.URL.Path)
+				assert.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data;"))
+
+				require.NoError(t, r.ParseMultipartForm(1<<20))
+
+				// The spec names the file field "file"; the server has to see a
+				// well formed part under that name, not just the right header.
+				file, header, err := r.FormFile("file")
+				require.NoError(t, err)
+				defer func() { require.NoError(t, file.Close()) }()
+
+				assert.Equal(t, tt.wantName, header.Filename)
+				assert.Equal(t, tt.wantType, header.Header.Get("Content-Type"))
+
+				content, err := io.ReadAll(file)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantContent, string(content))
+
+				assert.Equal(t, tt.req.Notes, r.FormValue("notes"))
+
+				w.WriteHeader(tt.statusCode)
+				_, err = w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			got, err := testClient(t, server).AttachFileToTransaction(context.Background(), 42, tt.req)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Contains(t, err.Error(), "attach file to transaction 42")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, int64(1234567890), got.ID)
+			assert.Equal(t, int64(1), got.UploadedBy)
+			assert.Equal(t, "receipt.png", got.Name)
+			assert.Equal(t, "image/png", got.Type)
+			assert.Equal(t, int64(4330), got.Size)
+			assert.Empty(t, got.Notes)
+			assert.Equal(t, time.Date(2025, 6, 11, 22, 33, 20, 294000000, time.UTC), got.CreatedAt)
+		})
+	}
+}
+
+func TestAttachFileToTransactionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *AttachFileRequest
+		wantErr string
+	}{
+		{
+			name:    "name is required",
+			req:     &AttachFileRequest{File: strings.NewReader("x")},
+			wantErr: "Name",
+		},
+		{
+			name:    "file is required",
+			req:     &AttachFileRequest{Name: "receipt.png"},
+			wantErr: "File",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusCreated)
+			}))
+			defer server.Close()
+
+			_, err := testClient(t, server).AttachFileToTransaction(context.Background(), 42, tt.req)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.False(t, called, "an invalid request should not reach the API")
+		})
+	}
+}
+
+func TestAttachFileRequestContentType(t *testing.T) {
+	tests := []struct {
+		name string
+		req  AttachFileRequest
+		want string
+	}{
+		{
+			name: "explicit type wins",
+			req:  AttachFileRequest{Name: "receipt.png", ContentType: "image/heic"},
+			want: "image/heic",
+		},
+		{
+			// Go's extension table is seeded from the host's mime files, so an
+			// extension it cannot place has to fall back rather than send "".
+			name: "unknown extension falls back",
+			req:  AttachFileRequest{Name: "receipt.notarealextension"},
+			want: "application/octet-stream",
+		},
+		{
+			name: "no extension falls back",
+			req:  AttachFileRequest{Name: "receipt"},
+			want: "application/octet-stream",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.req.contentType())
+		})
+	}
+}
+
+func TestGetTransactionAttachmentURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		wantURL    string
+		wantErr    string
+	}{
+		{
+			name:       "signed url",
+			statusCode: http.StatusOK,
+			response:   `{"url": "https://files.lunchmoney.app/66938-41ebb56a066bf09898de.png?X-Header1=X-Value1", "expires_at": "2025-07-14T12:00:00Z"}`,
+			wantURL:    "https://files.lunchmoney.app/66938-41ebb56a066bf09898de.png?X-Header1=X-Value1",
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			response:   `{"message": "Not Found", "errors": [{"errMsg": "File attachment 1234567890 not found"}]}`,
+			wantErr:    "File attachment 1234567890 not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				// The file endpoints are not nested under the transaction.
+				assert.Equal(t, "/transactions/attachments/1234567890", r.URL.Path)
+
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			got, err := testClient(t, server).GetTransactionAttachmentURL(context.Background(), 1234567890)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantURL, got.URL)
+			assert.Equal(t, time.Date(2025, 7, 14, 12, 0, 0, 0, time.UTC), got.ExpiresAt)
+		})
+	}
+}
+
+func TestDeleteTransactionAttachment(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		wantErr    string
+	}{
+		{
+			name:       "deleted",
+			statusCode: http.StatusNoContent,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			response:   `{"message": "Not Found", "errors": [{"errMsg": "File attachment 1234567890 not found"}]}`,
+			wantErr:    "delete transaction attachment 1234567890",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Equal(t, "/transactions/attachments/1234567890", r.URL.Path)
+				assert.Empty(t, r.URL.RawQuery)
+
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			err := testClient(t, server).DeleteTransactionAttachment(context.Background(), 1234567890)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/client.go
+++ b/client.go
@@ -133,9 +133,30 @@ func (c *Client) Delete(ctx context.Context, path string, options map[string]str
 	return c.do(ctx, http.MethodDelete, path, options, nil)
 }
 
-// do issues one request. The return values are named so that a failure to
-// close the response body still reaches the caller.
-func (c *Client) do(ctx context.Context, method, path string, options map[string]string, body any) (_ io.Reader, err error) {
+// do issues one request with body encoded as JSON.
+func (c *Client) do(ctx context.Context, method, path string, options map[string]string, body any) (io.Reader, error) {
+	var reader io.Reader
+
+	contentType := ""
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("could not marshal body: %w", err)
+		}
+		reader = bytes.NewReader(b)
+		contentType = "application/json"
+	}
+
+	return c.doBody(ctx, method, path, options, reader, contentType)
+}
+
+// doBody issues one request with an already encoded body, so that the endpoints
+// that do not take JSON share this response and error handling. An empty
+// contentType sends no Content-Type header.
+//
+// The return values are named so that a failure to close the response body
+// still reaches the caller.
+func (c *Client) doBody(ctx context.Context, method, path string, options map[string]string, reader io.Reader, contentType string) (_ io.Reader, err error) {
 	// JoinPath keeps the /v2 prefix on the base URL; assigning to u.Path would
 	// drop it and silently send every request to the wrong place.
 	u := c.Base.JoinPath(path)
@@ -146,22 +167,13 @@ func (c *Client) do(ctx context.Context, method, path string, options map[string
 	}
 	u.RawQuery = query.Encode()
 
-	var reader io.Reader
-	if body != nil {
-		b, err := json.Marshal(body)
-		if err != nil {
-			return nil, fmt.Errorf("could not marshal body: %w", err)
-		}
-		reader = bytes.NewReader(b)
-	}
-
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), reader)
 	if err != nil {
 		return nil, fmt.Errorf("could not create request: %w", err)
 	}
 
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	resp, err := c.HTTP.Do(req)


### PR DESCRIPTION
Wraps the three transaction attachment endpoints: `AttachFileToTransaction` (POST, multipart), `GetTransactionAttachmentURL` (GET, returns the signed url and its expiry) and `DeleteTransactionAttachment` (DELETE). The upload takes an `io.Reader` and a filename, so callers are not forced through the filesystem. `TransactionAttachment` in transactions.go is reused for the 201 body rather than defining a second type.

client.go: `Client.do` always marshals JSON, so the upload needed a second request path. Everything from `JoinPath` onwards — request construction, the response read, the 2xx check and the v2 error-body decoding — now lives in a new unexported `doBody`, which takes an already encoded reader and a content type; `do` keeps its exact signature and just marshals JSON and delegates. An empty content type sends no Content-Type header, which preserves today's behaviour of setting it only when there is a body. No exported method changed, and the existing client tests pass unmodified.

The move is a function-boundary change, not a text change: the error block that #37, #38 and #41 all patch is byte-identical and only shifts down a few lines, so their `ErrorResponse.RawBody` hunk still applies. I trial-merged this branch against all five open client.go PRs (#37, #38, #39, #40, #41) with `git merge-tree` and every one merges clean. `Client.Delete` is untouched, so #40's variadic body works either way (this code calls `c.Delete(ctx, path, nil)`); the const block at the top is untouched, so #39 is unaffected.

The multipart body sets a per-part Content-Type derived from the filename extension, since the API validates the file type and would otherwise only see `application/octet-stream`; `AttachFileRequest.ContentType` overrides it for the formats Go's mime table has no entry for (heic, heif). The 10MB cap and the allowed-type list live only in the spec's prose and its 400 examples, so they are documented rather than enforced client side.

One schema/example disagreement, resolved in favour of the schema: the 201 example carries a `source: "api"` field that `transactionAttachmentObject` does not declare and forbids via `additionalProperties: false`. `TransactionAttachment` leaves it out and decoding discards it; the test fixture includes it to show that is harmless.

Closes #31
