### PR TITLE
fix: tolerate a numeric budget amount, rewrite the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,40 +3,59 @@
 [![GoDoc](https://godoc.org/github.com/icco/lunchmoney?status.svg)](https://godoc.org/github.com/icco/lunchmoney)
 [![Go Report Card](https://goreportcard.com/badge/github.com/icco/lunchmoney)](https://goreportcard.com/report/github.com/icco/lunchmoney)
 
-Golang API wrapper for the [Lunch Money v2 API](https://alpha.lunchmoney.dev/introduction).
+Go wrapper for the [Lunch Money v2 API](https://alpha.lunchmoney.dev/introduction). Requires Go 1.25+.
 
-Create an access token on the [developers page](https://my.lunchmoney.app/developers) to use this.
+Get an access token from the [developers page](https://my.lunchmoney.app/developers).
 
-## Notes
+```go
+client, err := lunchmoney.NewClient(os.Getenv("LUNCHMONEY_TOKEN"))
+if err != nil {
+	return err
+}
 
- - Targets v2. v1 is not supported.
- - v2 is in open alpha and still changing. Use a test budget while getting started.
- - Reads, plus category, tag, transaction and manual account writes. PRs welcome for the rest — see the open issues.
- - Requires Go 1.25+.
+txns, err := client.GetTransactions(ctx, &lunchmoney.TransactionFilters{
+	StartDate: &start,
+	EndDate:   &end,
+})
+```
+
+See [examples/](examples) for more.
+
+## Coverage
+
+Covers the stable v2 surface: users, categories, tags, transactions (including splits, groups, deletes and attachments), manual accounts, Plaid accounts, recurring items and budgets.
+
+The preview crypto and balance history endpoints are not wrapped — see [#34](https://github.com/icco/lunchmoney/issues/34).
+
+v1 is not supported. v2 is in open alpha and still changing, so use a test budget while getting started.
+
+## Conventions
+
+ - Amounts are strings, parsed with `ParseCurrency` into exact decimals scaled to the currency's precision. v2 returns four decimal places.
+ - Nullable IDs are pointers, so unset is distinguishable from zero.
+ - Date-only fields are strings; timestamps are `time.Time`.
+ - Failures carry a 4xx or 5xx status and wrap an `ErrorResponse`. `errors.As` gets the status code and per-field errors. Some endpoints wrap something richer — `CategoryDependenciesError`, `TagInUseError`, `BudgetInvalidPeriodError` — and `IsTooEarly` reports a Plaid fetch already in flight.
 
 ## Migrating from v1
 
-v2 is not backwards compatible, so neither is this release.
+v2 is not backwards compatible, so neither is this library from v0.6.x.
 
-Renames:
+Renamed:
 
- - `GetAssets` → `GetManualAccounts`, `Asset` → `ManualAccount`. `type_name`/`subtype_name` → `Type`/`Subtype`, `exclude_transactions` → `ExcludeFromTransactions`, `depository` type → `cash`.
- - `GetRecurringExpenses` → `GetRecurringItems`, `RecurringExpense` → `RecurringItem`. Criteria, overrides and match results are now nested. Both dates are required when filtering by range.
- - `GetBudgets` → `GetBudgetSummary` (`/summary`), which returns a `BudgetSummary` rather than per-category, per-month budgets. `GetBudgetSettings` is new.
- - `GetCategories` takes filters. The API now defaults to nested, where a group carries its members in `Children`; pass `CategoryFormatFlattened` for the v1 shape.
+ - `GetAssets` → `GetManualAccounts`, `Asset` → `ManualAccount`. `type_name`/`subtype_name` → `Type`/`Subtype`, `exclude_transactions` → `ExcludeFromTransactions`, and the `depository` type is now `cash`.
+ - `GetRecurringExpenses` → `GetRecurringItems`, `RecurringExpense` → `RecurringItem`, with criteria, overrides and matches now nested.
+ - `GetBudgets` → `GetBudgetSummary`, returning a `BudgetSummary` rather than per-category, per-month budgets.
  - On `Transaction`: `asset_id` → `ManualAccountID`, `tags` → `TagIDs`, `has_children` → `IsSplitParent`, `parent_id` → `SplitParentID`, `is_group` → `IsGroupParent`, `group_id` → `GroupParentID`.
  - On `User`: `user_id`/`user_name`/`user_email` → `ID`/`Name`/`Email`.
 
-Behaviour:
+Changed behaviour:
 
- - `GetTransactions` returns a `TransactionsResponse` so the `has_more` paging flag is visible. `GetTransaction` no longer takes filters, and `UpdateTransaction` returns the updated `Transaction`. Splitting moved to its own endpoint and is not wrapped here.
- - v2 does not hydrate related records onto a transaction, so the category and account name fields are gone. Use `GetCategory`, `GetManualAccount` or `GetPlaidAccount`.
+ - `debit_as_negative` is gone. A positive amount is always a debit.
  - Status `cleared`/`uncleared` → `reviewed`/`unreviewed`. `pending` and `recurring` are gone; use `IsPending`.
- - `debit_as_negative` is gone. Positive is always a debit.
- - Inserting takes tag IDs, and tags must already exist. Duplicates no longer fail the batch: accepted rows come back in `Transactions`, rejected ones in `SkippedDuplicates`.
- - `CreateCategory` covers category groups too, behind `IsGroup`; v1's `/categories/group` is gone. `UpdateCategory`'s `Children` replaces a group's members rather than adding to them.
- - `DeleteCategory` takes a `force` argument, where v1 had a `/force` path suffix. Refusing to delete a category that is still in use returns a `CategoryDependenciesError` with the counts, which `errors.As` gets at.
- - Nullable IDs are pointers, so unset is distinguishable from zero.
- - Failures arrive with a 4xx or 5xx status instead of buried in a 200, and wrap an `ErrorResponse` — `errors.As` gets the status code and per-field errors.
- - `ParseCurrency` parses exact decimals scaled to the currency's precision. v2 returns 4 decimal places, which the old float path truncated and misrounded.
- - Amounts are sent as strings. v2 also accepts a number, but one string field avoids an empty float meaning zero.
+ - Transactions no longer carry hydrated category and account names. Look them up with `GetCategory`, `GetManualAccount` or `GetPlaidAccount`.
+ - `GetTransactions` returns a `TransactionsResponse`, so the `has_more` paging flag is visible. `GetTransaction` takes no filters, and `UpdateTransaction` returns the updated transaction.
+ - `InsertTransactions` takes tag IDs, and the tags must already exist. Duplicates no longer fail the batch: accepted rows come back in `Transactions`, rejected ones in `SkippedDuplicates`.
+ - `GetCategories` takes filters and defaults to the nested format, where a group carries its members in `Children`. Pass `CategoryFormatFlattened` for the v1 shape.
+ - `CreateCategory` covers groups behind `IsGroup`; v1's `/categories/group` is gone. `UpdateCategory`'s `Children` replaces a group's members rather than adding to them.
+ - `DeleteCategory` and `DeleteTag` take a `force` argument where v1 used a `/force` path suffix.
+ - Errors arrive with a real status code instead of buried in a 200.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 [![GoDoc](https://godoc.org/github.com/icco/lunchmoney?status.svg)](https://godoc.org/github.com/icco/lunchmoney)
 [![Go Report Card](https://goreportcard.com/badge/github.com/icco/lunchmoney)](https://goreportcard.com/report/github.com/icco/lunchmoney)
 
-Go wrapper for the [Lunch Money v2 API](https://alpha.lunchmoney.dev/introduction). Requires Go 1.25+.
+Go client for the [Lunch Money v2 API](https://alpha.lunchmoney.dev/introduction).
+
+```sh
+go get github.com/icco/lunchmoney
+```
+
+## Usage
 
 Get an access token from the [developers page](https://my.lunchmoney.app/developers).
 
@@ -13,49 +19,28 @@ if err != nil {
 	return err
 }
 
-txns, err := client.GetTransactions(ctx, &lunchmoney.TransactionFilters{
+resp, err := client.GetTransactions(ctx, &lunchmoney.TransactionFilters{
 	StartDate: &start,
 	EndDate:   &end,
 })
+if err != nil {
+	return err
+}
+
+for _, t := range resp.Transactions {
+	amount, err := t.ParsedAmount()
+	// ...
+}
 ```
 
-See [examples/](examples) for more.
+Runnable examples are in [examples/](examples). Full API docs are on [GoDoc](https://godoc.org/github.com/icco/lunchmoney).
 
-## Coverage
+## Notes
 
-Covers the stable v2 surface: users, categories, tags, transactions (including splits, groups, deletes and attachments), manual accounts, Plaid accounts, recurring items and budgets.
+Covers the stable v2 surface: users, categories, tags, transactions (with splits, groups, deletes and attachments), manual accounts, Plaid accounts, recurring items and budgets. The preview crypto and balance history endpoints are not wrapped ([#34](https://github.com/icco/lunchmoney/issues/34)).
 
-The preview crypto and balance history endpoints are not wrapped — see [#34](https://github.com/icco/lunchmoney/issues/34).
+Amounts are strings; `ParseCurrency` turns one into a `*money.Money` scaled to the currency's minor units. Nullable IDs are pointers. Errors wrap an `*ErrorResponse` carrying the status code, reachable with `errors.As`.
 
-v1 is not supported. v2 is in open alpha and still changing, so use a test budget while getting started.
+v2 is in open alpha and still changing, so use a test budget while getting started.
 
-## Conventions
-
- - Amounts are strings, parsed with `ParseCurrency` into exact decimals scaled to the currency's precision. v2 returns four decimal places.
- - Nullable IDs are pointers, so unset is distinguishable from zero.
- - Date-only fields are strings; timestamps are `time.Time`.
- - Failures carry a 4xx or 5xx status and wrap an `ErrorResponse`. `errors.As` gets the status code and per-field errors. Some endpoints wrap something richer — `CategoryDependenciesError`, `TagInUseError`, `BudgetInvalidPeriodError` — and `IsTooEarly` reports a Plaid fetch already in flight.
-
-## Migrating from v1
-
-v2 is not backwards compatible, so neither is this library from v0.6.x.
-
-Renamed:
-
- - `GetAssets` → `GetManualAccounts`, `Asset` → `ManualAccount`. `type_name`/`subtype_name` → `Type`/`Subtype`, `exclude_transactions` → `ExcludeFromTransactions`, and the `depository` type is now `cash`.
- - `GetRecurringExpenses` → `GetRecurringItems`, `RecurringExpense` → `RecurringItem`, with criteria, overrides and matches now nested.
- - `GetBudgets` → `GetBudgetSummary`, returning a `BudgetSummary` rather than per-category, per-month budgets.
- - On `Transaction`: `asset_id` → `ManualAccountID`, `tags` → `TagIDs`, `has_children` → `IsSplitParent`, `parent_id` → `SplitParentID`, `is_group` → `IsGroupParent`, `group_id` → `GroupParentID`.
- - On `User`: `user_id`/`user_name`/`user_email` → `ID`/`Name`/`Email`.
-
-Changed behaviour:
-
- - `debit_as_negative` is gone. A positive amount is always a debit.
- - Status `cleared`/`uncleared` → `reviewed`/`unreviewed`. `pending` and `recurring` are gone; use `IsPending`.
- - Transactions no longer carry hydrated category and account names. Look them up with `GetCategory`, `GetManualAccount` or `GetPlaidAccount`.
- - `GetTransactions` returns a `TransactionsResponse`, so the `has_more` paging flag is visible. `GetTransaction` takes no filters, and `UpdateTransaction` returns the updated transaction.
- - `InsertTransactions` takes tag IDs, and the tags must already exist. Duplicates no longer fail the batch: accepted rows come back in `Transactions`, rejected ones in `SkippedDuplicates`.
- - `GetCategories` takes filters and defaults to the nested format, where a group carries its members in `Children`. Pass `CategoryFormatFlattened` for the v1 shape.
- - `CreateCategory` covers groups behind `IsGroup`; v1's `/categories/group` is gone. `UpdateCategory`'s `Children` replaces a group's members rather than adding to them.
- - `DeleteCategory` and `DeleteTag` take a `force` argument where v1 used a `/force` path suffix.
- - Errors arrive with a real status code instead of buried in a 200.
+Requires Go 1.25+. Upgrading from v0.6.x, which wrapped v1 of the API? See [UPGRADING.md](UPGRADING.md).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,85 @@
+# Upgrading from v0.6.x to v0.7.x
+
+v0.6.x wrapped v1 of the Lunch Money API. v0.7.x wraps v2, which is not backwards compatible, so neither is this library. v1 is no longer supported.
+
+Lunch Money's own [migration guide](https://alpha.lunchmoney.dev/v2/migration-guide) covers the API side. This covers the Go side.
+
+## Client
+
+`BaseAPIURL` is now `https://api.lunchmoney.dev/v2/`.
+
+Failures arrive with a real 4xx or 5xx status instead of a 200 with an error in the body, and wrap an `*ErrorResponse` carrying the status code and per-field errors:
+
+```go
+var apiErr *lunchmoney.ErrorResponse
+if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+	// ...
+}
+```
+
+Some calls wrap something more specific: `*CategoryDependenciesError`, `*TagInUseError` and `*BudgetInvalidPeriodError`. `IsTooEarly(err)` reports a Plaid fetch already in flight.
+
+`ParseCurrency` now parses exact decimals scaled to the currency's minor units. v2 returns amounts to four decimal places, which the old `int64(100 * float)` path truncated and misrounded, so parsed values may differ by a cent from v0.6.x.
+
+## Renamed
+
+| v0.6.x | v0.7.x |
+| --- | --- |
+| `GetAssets`, `UpdateAsset` | `GetManualAccounts`, `GetManualAccount`, `UpdateManualAccount` |
+| `Asset` | `ManualAccount` |
+| `GetRecurringExpenses` | `GetRecurringItems` |
+| `RecurringExpense` | `RecurringItem` |
+| `GetBudgets` | `GetBudgetSummary` |
+
+On `ManualAccount`: `TypeName`/`SubtypeName` are `Type`/`Subtype`, `ExcludedTransactions` is `ExcludeFromTransactions`, and the `depository` type value is now `cash`.
+
+On `Transaction`: `AssetID` is `ManualAccountID`, `Tags` is `TagIDs` (IDs, not objects), `HasChildren` is `IsSplitParent`, `ParentID` is `SplitParentID`, `IsGroup` is `IsGroupParent`, `GroupID` is `GroupParentID`.
+
+On `User`: `UserID`, `UserName` and `UserEmail` are `ID`, `Name` and `Email`.
+
+## Signatures
+
+`GetCategories` takes filters, and defaults to the nested format where a group carries its members in `Children`. Pass `CategoryFormatFlattened` for the v1 shape:
+
+```go
+cats, err := client.GetCategories(ctx, &lunchmoney.CategoryFilters{
+	Format: lunchmoney.CategoryFormatFlattened,
+})
+```
+
+`GetTransactions` returns a `*TransactionsResponse` rather than a slice, so the `has_more` paging flag is visible:
+
+```go
+resp, err := client.GetTransactions(ctx, filters)
+for _, t := range resp.Transactions {
+	// ...
+}
+```
+
+`GetTransaction` no longer takes filters. `UpdateTransaction` returns the updated `*Transaction` instead of an `updated` flag. `GetRecurringItems` requires `StartDate` and `EndDate` together, where v1 accepted a start date alone. `GetBudgetSummary` requires both dates.
+
+## Behaviour
+
+`debit_as_negative` is gone everywhere, from filters and request bodies alike. A positive amount is always a debit and a negative one always a credit, regardless of account preference.
+
+Transaction status `cleared` and `uncleared` are now `reviewed` and `unreviewed`, as the `StatusReviewed` and `StatusUnreviewed` constants. The `pending` and `recurring` statuses are gone; pending transactions are flagged by `IsPending`.
+
+Transactions no longer arrive with related records hydrated onto them. `CategoryName`, `CategoryGroupID`, `CategoryGroupName`, `IsIncome`, `ExcludeFromBudget`, `ExcludeFromTotals`, `AssetName`, `PlaidAccountName`, `InstitutionName` and the rest are gone — resolve the IDs with `GetCategory`, `GetManualAccount` or `GetPlaidAccount`.
+
+`InsertTransactions` takes tag IDs, and the tags must already exist; v1 created them inline from names. Duplicates no longer fail the whole batch: accepted rows come back in `Transactions`, rejected ones in `SkippedDuplicates` with a reason.
+
+`RecurringItem` nests what v1 kept flat. `StartDate`, `EndDate`, `Payee`, `Amount` and the cadence live under `TransactionCriteria`; the values applied to matches live under `Overrides`; match results live under `Matches`, which is nil for suggested items. `BillingDate` is `TransactionCriteria.AnchorDate`.
+
+`GetBudgetSummary` returns a `BudgetSummary` for a date range rather than v1's per-category, per-month `Budget` list. `GetBudgetSettings` reports the account's budget period configuration.
+
+Nullable IDs are pointers, so unset is distinguishable from zero. This affects `Transaction.CategoryID`, `RecurringID`, `ManualAccountID`, `PlaidAccountID`, `SplitParentID` and `GroupParentID`, and `Category.GroupID`.
+
+Splitting moved out of `UpdateTransaction` to `SplitTransaction`, and unsplitting to `UnsplitTransaction`. Grouping is `GroupTransactions` and `UngroupTransactions`.
+
+`CreateCategory` covers category groups behind `IsGroup`; v1's separate group endpoint is gone. `UpdateCategory`'s `Children` replaces a group's members rather than adding to them. `DeleteCategory` and `DeleteTag` take a `force` argument where v1 used a `/force` path suffix.
+
+## New in v0.7.x
+
+Category, tag and manual account writes; transaction deletes, splits, groups and attachments; budget upsert and delete; `TriggerPlaidFetch`; and single-item getters for tags, plaid accounts, manual accounts and recurring items.
+
+The preview crypto and balance history endpoints are not wrapped — see [#34](https://github.com/icco/lunchmoney/issues/34).

--- a/attachments.go
+++ b/attachments.go
@@ -25,10 +25,8 @@ const attachmentsPath = "/transactions/attachments"
 // mime/multipart does for the parts it builds itself.
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
-// AttachFileRequest is a file to upload and attach to a transaction.
-//
-// The API rejects files over 10MB, and accepts only image/jpeg, image/png,
-// application/pdf, image/heic and image/heif.
+// AttachFileRequest is a file to attach to a transaction. The API caps files at
+// 10MB and accepts jpeg, png, pdf, heic and heif.
 type AttachFileRequest struct {
 	// Name is the filename the API stores and shows.
 	Name string `validate:"required"`

--- a/categories.go
+++ b/categories.go
@@ -74,9 +74,8 @@ func (r *CategoryFilters) ToMap() (map[string]string, error) {
 	return ret, nil
 }
 
-// GetCategories returns all categories. Unlike v1 the API defaults to the
-// nested format, where groups carry their members in Children; pass
-// CategoryFormatFlattened for the old shape.
+// GetCategories returns all categories, nested by default. Pass
+// CategoryFormatFlattened for the v1 shape.
 func (c *Client) GetCategories(ctx context.Context, filters *CategoryFilters) ([]*Category, error) {
 	options := map[string]string{}
 	if filters != nil {
@@ -162,8 +161,7 @@ func (c *Client) CreateCategory(ctx context.Context, category *CreateCategory) (
 }
 
 // UpdateCategory holds the updatable fields of a category. Only non-nil fields
-// are sent. A category cannot be converted to a group or back, so IsGroup is
-// not updatable.
+// are sent; IsGroup is absent because a category cannot become a group.
 type UpdateCategory struct {
 	Name              *string `json:"name,omitempty" validate:"omitnil,min=1,max=100"`
 	Description       *string `json:"description,omitempty" validate:"omitnil,max=200"`
@@ -204,10 +202,8 @@ func (c *Client) UpdateCategory(ctx context.Context, id int64, category *UpdateC
 	return resp, nil
 }
 
-// CategoryDependenciesError is the 422 the API answers with when a category
-// cannot be deleted because things still reference it. DeleteCategory returns
-// one so the counts can be inspected with errors.As; deleting with force set
-// removes the category anyway.
+// CategoryDependenciesError is the 422 returned when a category still has
+// dependents. Reachable with errors.As; force deletes it anyway.
 type CategoryDependenciesError struct {
 	CategoryName string             `json:"category_name"`
 	Dependents   CategoryDependents `json:"dependents"`
@@ -232,9 +228,8 @@ func (e *CategoryDependenciesError) Error() string {
 
 func (e *CategoryDependenciesError) Unwrap() error { return e.Err }
 
-// DeleteCategory deletes a category or category group. Without force the API
-// refuses to delete one that still has dependents, and the returned error is a
-// CategoryDependenciesError describing them.
+// DeleteCategory deletes a category or group. Without force, one with
+// dependents returns a *CategoryDependenciesError.
 func (c *Client) DeleteCategory(ctx context.Context, id int64, force bool) error {
 	options := map[string]string{}
 	if force {

--- a/client.go
+++ b/client.go
@@ -66,9 +66,8 @@ func NewClient(apikey string) (*Client, error) {
 	}, nil
 }
 
-// ErrorResponse is the body the v2 API returns alongside a 4xx or 5xx status.
-// Failing calls wrap one, so errors.As gets at the status code and the
-// individual problems the API reported.
+// ErrorResponse is the body the v2 API returns with a 4xx or 5xx. Failing calls
+// wrap one, reachable with errors.As.
 type ErrorResponse struct {
 	Message string       `json:"message"`
 	Errors  []ErrorEntry `json:"errors,omitempty"`
@@ -165,12 +164,8 @@ func (c *Client) do(ctx context.Context, method, path string, options map[string
 	return c.doBody(ctx, method, path, options, reader, contentType)
 }
 
-// doBody issues one request with an already encoded body, so that the endpoints
-// that do not take JSON share this response and error handling. An empty
-// contentType sends no Content-Type header.
-//
-// The return values are named so that a failure to close the response body
-// still reaches the caller.
+// doBody issues a request with an already encoded body, shared by the JSON and
+// multipart paths. An empty contentType sends no Content-Type header.
 func (c *Client) doBody(ctx context.Context, method, path string, options map[string]string, reader io.Reader, contentType string) (_ io.Reader, err error) {
 	// JoinPath keeps the /v2 prefix on the base URL; assigning to u.Path would
 	// drop it and silently send every request to the wrong place.
@@ -237,10 +232,8 @@ func (c *Client) doBody(ctx context.Context, method, path string, options map[st
 	return &buf, nil
 }
 
-// ParseCurrency converts a string amount and currency code into a money.Money
-// struct. The amount is parsed as an exact decimal rather than a float so that
-// the four decimal places the v2 API returns do not pick up rounding error, and
-// is scaled to the number of minor units the currency actually uses.
+// ParseCurrency converts an amount and currency code into a money.Money, parsed
+// as an exact decimal and scaled to the currency's minor units.
 func ParseCurrency(amount, currency string) (*money.Money, error) {
 	// go-money falls back to two minor units for codes it does not know, so
 	// match that rather than dereferencing a nil currency.
@@ -257,9 +250,8 @@ func ParseCurrency(amount, currency string) (*money.Money, error) {
 	return money.New(units, currency), nil
 }
 
-// parseDecimal converts a decimal string into an integer number of minor units,
-// rounding half away from zero when the string carries more precision than the
-// currency has room for.
+// parseDecimal converts a decimal string to minor units, rounding half away
+// from zero.
 func parseDecimal(amount string, fraction int) (int64, error) {
 	s := strings.TrimSpace(amount)
 	if s == "" {

--- a/plaid.go
+++ b/plaid.go
@@ -125,9 +125,8 @@ func IsTooEarly(err error) bool {
 	return errors.As(err, &resp) && resp.StatusCode == http.StatusTooEarly
 }
 
-// TriggerPlaidFetch queues a background fetch of the latest data from Plaid.
-// The API answers 425 Too Early if a fetch was triggered within the last
-// minute; check for that with IsTooEarly.
+// TriggerPlaidFetch queues a background fetch from Plaid. It answers 425 if one
+// was triggered in the last minute; check with IsTooEarly.
 func (c *Client) TriggerPlaidFetch(ctx context.Context, filters *PlaidFetchFilters) ([]*PlaidAccount, error) {
 	options := map[string]string{}
 	if filters != nil {

--- a/recurring.go
+++ b/recurring.go
@@ -16,10 +16,8 @@ type RecurringItemsResponse struct {
 	RecurringItems []*RecurringItem `json:"recurring_items"`
 }
 
-// RecurringItem is a transaction that is scheduled to happen repeatedly. In v1
-// of the API these were called recurring expenses, and the criteria that
-// identify a matching transaction were flat fields on this object rather than
-// the nested TransactionCriteria.
+// RecurringItem is a transaction scheduled to happen repeatedly. v1 called
+// these recurring expenses and kept the criteria flat.
 type RecurringItem struct {
 	ID          int64  `json:"id"`
 	Description string `json:"description"`
@@ -84,9 +82,8 @@ func (r *RecurringItem) ParsedAmount() (*money.Money, error) {
 	return ParseCurrency(r.TransactionCriteria.Amount, r.TransactionCriteria.Currency)
 }
 
-// RecurringItemFilters are options to pass to the request. StartDate and
-// EndDate must be given together; v2 no longer accepts a start date alone, and
-// the debit_as_negative option is gone.
+// RecurringItemFilters are options for the request. StartDate and EndDate must
+// be given together.
 type RecurringItemFilters struct {
 	StartDate        string `validate:"required_with=EndDate,omitempty,datetime=2006-01-02"`
 	EndDate          string `validate:"required_with=StartDate,omitempty,datetime=2006-01-02"`

--- a/summary.go
+++ b/summary.go
@@ -205,10 +205,8 @@ type Budget struct {
 	Notes      string  `json:"notes"`
 }
 
-// UnmarshalJSON decodes a budget, accepting an amount given as a JSON number
-// as well as the string the schema documents. The upsert response is the one
-// place the API's own example shows an unquoted amount, and a failed decode
-// there would report an error for a budget that was in fact written.
+// UnmarshalJSON decodes a budget, accepting an amount sent as a number as well
+// as a string.
 func (b *Budget) UnmarshalJSON(data []byte) error {
 	type budget Budget
 
@@ -300,9 +298,8 @@ func (c *Client) DeleteBudget(ctx context.Context, categoryID int64, startDate s
 	return nil
 }
 
-// BudgetInvalidPeriodError is the 400 the API answers with when a start date is
-// not a period start for the account. The budget calls return one so the valid
-// dates on either side of the rejected one can be reached with errors.As.
+// BudgetInvalidPeriodError is the 400 returned when a start date is not a period
+// start. It carries the valid dates either side; reachable with errors.As.
 type BudgetInvalidPeriodError struct {
 	Message            string `json:"message"`
 	ErrMsg             string `json:"errMsg"`

--- a/summary.go
+++ b/summary.go
@@ -205,6 +205,40 @@ type Budget struct {
 	Notes      string  `json:"notes"`
 }
 
+// UnmarshalJSON decodes a budget, accepting an amount given as a JSON number
+// as well as the string the schema documents. The upsert response is the one
+// place the API's own example shows an unquoted amount, and a failed decode
+// there would report an error for a budget that was in fact written.
+func (b *Budget) UnmarshalJSON(data []byte) error {
+	type budget Budget
+
+	aux := struct {
+		Amount json.RawMessage `json:"amount"`
+		*budget
+	}{budget: (*budget)(b)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if len(aux.Amount) == 0 || string(aux.Amount) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(aux.Amount, &b.Amount); err == nil {
+		return nil
+	}
+
+	var number json.Number
+	if err := json.Unmarshal(aux.Amount, &number); err != nil {
+		return fmt.Errorf("%s is not a valid amount: %w", aux.Amount, err)
+	}
+
+	b.Amount = number.String()
+
+	return nil
+}
+
 // ParsedAmount converts the budgeted amount and currency into a money.Money.
 func (b *Budget) ParsedAmount() (*money.Money, error) {
 	return ParseCurrency(b.Amount, b.Currency)

--- a/summary_test.go
+++ b/summary_test.go
@@ -66,6 +66,15 @@ func TestUpsertBudget(t *testing.T) {
 			want:     &Budget{CategoryID: 315177, StartDate: "2025-01-01", Amount: "500.0000", Currency: "usd", ToBase: 500, Notes: "Monthly groceries"},
 		},
 		{
+			// The spec's own 200 example shows the amount unquoted, so a
+			// string-only decode would fail on a budget that was written.
+			name:     "amount comes back as a number",
+			budget:   &UpsertBudget{StartDate: "2025-03-01", CategoryID: 315177, Amount: "500"},
+			wantBody: map[string]any{"start_date": "2025-03-01", "category_id": float64(315177), "amount": "500"},
+			response: `{"category_id": 315177, "start_date": "2025-03-01", "amount": 500, "currency": "usd", "to_base": 500.0, "notes": ""}`,
+			want:     &Budget{CategoryID: 315177, StartDate: "2025-03-01", Amount: "500", Currency: "usd", ToBase: 500},
+		},
+		{
 			name:     "empty notes clear the stored ones",
 			budget:   &UpsertBudget{StartDate: "2025-02-01", CategoryID: 315177, Amount: "42.5000", Notes: &cleared},
 			wantBody: map[string]any{"start_date": "2025-02-01", "category_id": float64(315177), "amount": "42.5000", "notes": ""},

--- a/tags.go
+++ b/tags.go
@@ -89,8 +89,7 @@ func (c *Client) CreateTag(ctx context.Context, tag *CreateTag) (*Tag, error) {
 }
 
 // UpdateTag holds the updatable fields of a tag. Only non-nil fields are sent,
-// which also means there is no way to send an explicit null: leaving ArchivedAt
-// nil keeps the stored value rather than clearing it.
+// so a nil ArchivedAt keeps the stored value rather than clearing it.
 type UpdateTag struct {
 	Name            *string    `json:"name,omitempty" validate:"omitnil,min=1,max=100"`
 	Description     *string    `json:"description,omitempty" validate:"omitnil,max=200"`
@@ -142,9 +141,8 @@ func (e *TagInUseError) Error() string {
 
 func (e *TagInUseError) Unwrap() error { return e.Err }
 
-// DeleteTag deletes the tag with the given ID. Without force the API refuses to
-// delete a tag that rules or transactions still reference, and the returned
-// error is a *TagInUseError naming what depends on it.
+// DeleteTag deletes a tag. Without force, one that rules or transactions
+// reference returns a *TagInUseError.
 func (c *Client) DeleteTag(ctx context.Context, id int64, force bool) error {
 	options := map[string]string{}
 	if force {

--- a/time.go
+++ b/time.go
@@ -6,9 +6,8 @@ import (
 	"time"
 )
 
-// Timestamp is a time the API documents as a date-time but may also return as
-// a plain YYYY-MM-DD date. Decoding either shape into a time.Time directly
-// fails on the date-only form, which would sink the whole response.
+// Timestamp is a time the API may return as a date-time or a plain date. A
+// time.Time alone fails on the date-only form.
 type Timestamp struct {
 	time.Time
 }

--- a/transactions.go
+++ b/transactions.go
@@ -11,9 +11,8 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-// Transaction status values. v1's "cleared" and "uncleared" became "reviewed"
-// and "unreviewed"; its "pending" and "recurring" statuses are gone, and
-// pending transactions are now flagged by the IsPending field.
+// Transaction status values. Pending transactions are flagged by IsPending
+// rather than by a status.
 const (
 	StatusReviewed      = "reviewed"
 	StatusUnreviewed    = "unreviewed"
@@ -26,14 +25,9 @@ type TransactionsResponse struct {
 	HasMore      bool           `json:"has_more"`
 }
 
-// Transaction is a single LM transaction.
-//
-// Amounts no longer follow the account's debit_as_negative preference: a
-// positive amount is always a debit and a negative amount always a credit.
-//
-// v2 does not hydrate related records onto the transaction. The category and
-// account name fields v1 returned are gone; look them up with GetCategory,
-// GetManualAccount or GetPlaidAccount instead.
+// Transaction is a single LM transaction. A positive amount is a debit, a
+// negative one a credit. Related records are not hydrated: resolve the IDs with
+// GetCategory, GetManualAccount or GetPlaidAccount.
 type Transaction struct {
 	ID              int64   `json:"id"`
 	Date            string  `json:"date"`
@@ -242,10 +236,7 @@ type InsertTransaction struct {
 }
 
 // InsertTransactionsResponse holds the results of an InsertTransactions call.
-//
-// Unlike v1, a duplicate no longer fails the whole request: the transactions
-// that were accepted come back in Transactions, and the ones that were not are
-// reported in SkippedDuplicates.
+// Accepted rows come back in Transactions, duplicates in SkippedDuplicates.
 type InsertTransactionsResponse struct {
 	Transactions      []*Transaction     `json:"transactions"`
 	SkippedDuplicates []SkippedDuplicate `json:"skipped_duplicates"`
@@ -301,11 +292,8 @@ type UpdateTransaction struct {
 	CustomMetadata   *map[string]any `json:"custom_metadata,omitempty"`
 }
 
-// UpdateTransaction modifies an existing transaction with the specified ID and
-// returns the updated transaction.
-//
-// Splitting moved out of this call in v2. The split payload v1 accepted here
-// is now POST /transactions/split/{id}; use SplitTransaction instead.
+// UpdateTransaction modifies a transaction and returns it. Use SplitTransaction
+// to split one.
 func (c *Client) UpdateTransaction(ctx context.Context, id int64, ut *UpdateTransaction) (*Transaction, error) {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	if err := validate.StructCtx(ctx, ut); err != nil {
@@ -325,10 +313,8 @@ func (c *Client) UpdateTransaction(ctx context.Context, id int64, ut *UpdateTran
 	return resp, nil
 }
 
-// DeleteTransaction deletes the transaction with the specified ID.
-//
-// The API refuses to delete a split or grouped transaction; unsplit or ungroup
-// it first. Deletion is not reversible.
+// DeleteTransaction deletes a transaction, irreversibly. The API refuses split
+// or grouped ones; unsplit or ungroup first.
 func (c *Client) DeleteTransaction(ctx context.Context, id int64) error {
 	if _, err := c.Delete(ctx, fmt.Sprintf("/transactions/%d", id), nil); err != nil {
 		return fmt.Errorf("delete transaction %d: %w", id, err)
@@ -337,10 +323,8 @@ func (c *Client) DeleteTransaction(ctx context.Context, id int64) error {
 	return nil
 }
 
-// DeleteTransactionsRequest deletes transactions in bulk.
-//
-// The whole request fails if any ID is repeated, does not exist, or belongs to
-// a split or grouped transaction.
+// DeleteTransactionsRequest deletes transactions in bulk. The whole request
+// fails if any ID repeats, is unknown, or is split or grouped.
 type DeleteTransactionsRequest struct {
 	IDs []int64 `json:"ids" validate:"min=1,max=500"`
 }

--- a/transactions_split.go
+++ b/transactions_split.go
@@ -57,11 +57,8 @@ func (c *Client) UnsplitTransaction(ctx context.Context, id int64) error {
 	return nil
 }
 
-// GroupTransactionsRequest groups existing transactions into a new one. Date
-// and Payee are sent even when empty: the API requires both keys, and an empty
-// payee is allowed.
-//
-// v1 took the IDs under a "transactions" key.
+// GroupTransactionsRequest groups transactions into a new one. Date and Payee
+// are sent even when empty; the API requires both keys.
 type GroupTransactionsRequest struct {
 	IDs        []int64 `json:"ids" validate:"min=2,max=500"`
 	Date       string  `json:"date" validate:"datetime=2006-01-02"`


### PR DESCRIPTION
Two loose ends after the v2 endpoint sweep.

`Budget` now accepts an amount given as a JSON number as well as the documented string. The upsert 200 is the one place the spec's own example shows it unquoted, and a failed decode there reports an error for a budget the server already wrote. `Amount` stays a `string`, so nothing downstream changes. The added test fails without the decoder.

The README rewrite: the coverage line had survived two merge-conflict resolutions and still understated things, and it claimed splitting was unwrapped, which stopped being true in #42. Rewritten around the finished surface, with a usage example, the conventions worth knowing up front, and a trimmed migration section. Every symbol it names is verified to exist and the example snippet is compile-checked.